### PR TITLE
[Docs] Scope PDF-template reads to the <script> block (~2,000 tok/doc)

### DIFF
--- a/references/pdf-reports.md
+++ b/references/pdf-reports.md
@@ -13,7 +13,11 @@
 ```
 1. ก๊อป template:  cp assets/guide-template.html  qa/<feat>/guide/guide.html
    (หรือ bug-report-template.html)
-2. แก้ data array ในแท็ก <script> ให้ตรงเนื้อหา (scenario/step/field หรือ bug)
+2. แก้ data array ในแท็ก <script> ให้ตรงเนื้อหา (scenario/step/field หรือ bug).
+   **token discipline:** Edit บังคับ Read ก่อน → อย่าอ่านทั้งไฟล์ (CSS ครึ่งไฟล์ไม่ต้องแตะ).
+   อ่านเฉพาะบล็อก `<script>` — `Read offset:57` (guide) / `offset:42` (bug-report); anchor คือ
+   บรรทัด `<script>` เผื่อเลขบรรทัดขยับ. วัดจริง (tiktoken): เต็มไฟล์ 4,029 tok → block 1,890 tok
+   = ประหยัด ~2,000 tok/เอกสาร (53%).
 3. วาง screenshot ไว้ใน guide/shots/ (ถ่ายจาก run จริง — ดูหัวข้อ "ถ่ายภาพไฮไลต์")
 4. สร้าง PDF:
      agent-browser open "file:///ABS/PATH/guide.html"


### PR DESCRIPTION
## สรุป
เพิ่มคำสั่ง scoped-read ใน `references/pdf-reports.md` (recipe ขั้น 2): แก้ `data[]` ให้ Read เฉพาะบล็อก `<script>` ไม่ใช่ทั้งไฟล์ — ตัด CSS ที่ไม่เกี่ยวออกจาก context

## วัดจริง (tiktoken o200k_base)
| template | อ่านเต็ม | `<script>` block | ประหยัด |
|---|--:|--:|--:|
| guide | 4,029 tok | 1,890 tok | **2,139 (53%)** |
| bug-report | 3,542 tok | 1,606 tok | **1,936 (54%)** |

per-artifact token load ที่ใหญ่สุดของ skill, แก้แบบ docs-only ไม่มีความเสี่ยง

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)