### PR TITLE
[Docs] Sharpen the batch efficiency rationale in SKILL.md §4

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -113,8 +113,9 @@ QA layers: (1) Smoke = happy path completes + errors empty · (2) Functional = a
 (`a11y`, `perf_budget` in flow.yaml) and return only short numbers — never a full node/timing dump.
 
 **Store test cases as repeatable files** (regression/repro) → write them as flow YAML:
-`references/flow-spec.md`. **Reduce round-trips / daemon stalls** with `batch` + a pre-flight
-health-check → `references/commands.md`.
+`references/flow-spec.md`. **Fewer process spawns + fewer `os 10060` stalls:** `batch` several
+commands into one invocation (`@eN` refs persist across them) instead of one CLI call each; run a
+pre-flight health-check before a long flow → `references/commands.md`.
 
 Suggested artifact layout:
 ```


### PR DESCRIPTION
`batch` มี pointer อยู่แล้วแต่ไม่มี "why" — ทำให้เหตุผล runtime ชัด: ลด process spawn + ลด os-10060 stall โดยรวมหลายคำสั่งใน invocation เดียว (`@eN` refs persist) + pre-flight health-check

หมายเหตุ: เป็น runtime/reliability ไม่ใช่ประหยัด token (batch คืน content เท่าเดิม)

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)