### PR TITLE
[Docs] Note the NetSuite exception in README gotchas table

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Golden rule: `click` does not auto-scroll, so call `scrollintoview` first; and d
 |---|---|---|
 | `click` doesn't auto-scroll | button below fold → CLI `✓ Done` but nothing happens | `scrollintoview <sel>` before `click` |
 | Don't trust `✓ Done` | command succeeds but has no effect | assert state after every action (`wait` / `get url` / `get text`) |
-| `os error 10060` | `wait --text` / `wait <selector>` flakes on Windows | use `wait --load networkidle` + short state checks |
+| `os error 10060` | `wait --text` / `wait <selector>` flakes on Windows | use `wait --load networkidle` + short state checks (NetSuite: `wait --fn "jQuery.active===0"` — networkidle never settles there) |
 | headless has no Thai font | injected Thai labels render as boxes | put Thai text in the HTML, bake only the ring into the image |
 | `pdf` double-pagination | paged.js PDF gets alternating blank pages | fit `@page size` + `.pagedjs_page` margin on screen only |
 


### PR DESCRIPTION
ตาราง gotchas ใน README แนะนำ `wait --load networkidle` เป็น fix ของ os-10060 แบบไม่มีข้อยกเว้น — บน NetSuite networkidle โพลไม่จบ. เพิ่มทางเลือก NetSuite (`wait --fn jQuery.active===0`) ให้ตรงกับ SKILL.md rule #3 + commands.md

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)