### PR TITLE
[Docs] Update CLAIMS-AUDIT + self-test for the 5 merged doc PRs

### DIFF
--- a/docs/CLAIMS-AUDIT.md
+++ b/docs/CLAIMS-AUDIT.md
@@ -92,9 +92,9 @@ verify fix 100%".
 
 | claim | file | adjudication |
 |---|---|---|
-| `@page` margin-box `counter(page)` doesn't work in Chrome `printToPDF` (justifies paged.js) | pdf-reports L23 | **REFUTED on Chrome 150 (2026-07-14)** — `@bottom-center{content:counter(page)}` DID render in `agent-browser pdf` (footer on all 3 test pages). Version-drift: broke on old Chrome, works now. pdf-reports.md updated + paged.js kept (still needed for TOC `target-counter`). |
-| paged.js + printToPDF **double-pagination** (blank even pages, page# ×2) | pdf-reports L30 | **CONFIRMED (2026-07-14)** — no fixes → 3 logical pages became **6** PDF pages, even pages footer-only; fixes → clean 3. Matches the wording exactly. `verified` added + `self-test/pdf/` shipped. |
-| headless has no Thai font → boxes | pdf-reports L54 | duplicate of gotchas #5; widely-known → low real risk |
+| `@page` margin-box `counter(page)` doesn't work in Chrome `printToPDF` (justifies paged.js) | pdf-reports L32 | **REFUTED on Chrome 150 (2026-07-14)** — `@bottom-center{content:counter(page)}` DID render in `agent-browser pdf` (footer on all 3 test pages). Version-drift: broke on old Chrome, works now. pdf-reports.md updated + paged.js kept (still needed for TOC `target-counter`). |
+| paged.js + printToPDF **double-pagination** (blank even pages, page# ×2) | pdf-reports L41 | **CONFIRMED (2026-07-14)** — no fixes → 3 logical pages became **6** PDF pages, even pages footer-only; fixes → clean 3. Matches the wording exactly. `verified` added + `self-test/pdf/` shipped. |
+| headless has no Thai font → boxes | pdf-reports L67 | duplicate of gotchas #5; widely-known → low real risk |
 | wait-before-assert fixes timing-flaky assert | reliability §2 | restates golden rule #2 (verified); testable but timing-flaky to automate |
 | don't `mark_end` at click's `✓ Done` = bogus number | perf §2 | corollary of golden rule #2 (verified) |
 | delete `~/.agent-browser/<session>.*` fixes stuck 10060 | reliability §1 | restates gotchas #3 ("observed 2026-07-05") — inherits its provenance |
@@ -115,3 +115,25 @@ in the audited surface. The lesson recurred: an unverified causal claim was 50/5
   fields exist. Catches tool-version drift on the a11y/perf recipes.
 - The spec/schema claims (flow YAML) are validated by the flow runner itself + `examples/saucedemo.yaml`
   — running that example end-to-end is their regression check.
+
+---
+
+## Round 3 — post-refactor claims (2026-07-17)
+
+Five doc PRs merged (NetSuite scope-out + networkidle caveat #2, PDF template scoped-read #4, trim
+black-window rule #4 #8, batch rationale #9, README networkidle #10). Two of them add a claim the
+ledger must carry; one shifted line refs (fixed in the Round-2 table above: L23→L32, L30→L41, L54→L67).
+
+| # | Claim | Location | Type | Provenance | Risk | Smoke |
+|---|-------|----------|------|-----------|------|-------|
+| 19 | `wait --load networkidle` never settles on NetSuite → use `wait --fn "jQuery.active===0"` | SKILL §3/§4 · commands.md · README · pdf boundary | causal | **cross-ref to netsuite-qa-browser; NOT A/B'd in this repo** | MED | no (harness has no NetSuite) |
+| 20 | scoped Read of the template `<script>` block saves ~half the tokens vs the whole file | pdf-reports step 2 | efficiency | **measured 2026-07-17** — tiktoken o200k_base: guide 4,029→1,890 tok (53%), bug-report 54%; byte proxy 49%/52% | LOW | ✅ (drift gate ≥40%) |
+
+**On #19 (the one to watch):** this is a causal claim of the exact class the audit exists to flag —
+stated as fact, no A/B here. It is **inherited** from `netsuite-qa-browser` (where NetSuite lives), not
+proven in this repo. Do not promote it to "verified" in this skill; if a NetSuite target is ever added
+to the harness, A/B it (networkidle vs `jQuery.active===0`) then relabel. Trimming rule #4 (#8) removed
+a *duplicate* of gotchas #9, not a claim — no ledger change beyond the line-ref fix.
+
+`self-test/smoke-test.sh` now gates #20 with a pure-file check (`<script>` block ≥40% smaller than the
+full template) — runs without agent-browser, so it stays green even where the browser harness can't.

--- a/self-test/README.md
+++ b/self-test/README.md
@@ -25,7 +25,9 @@ other sessions. Exit code is non-zero if any check fails.
 | `open about:blank` → `get url` reflects it (black window ≠ bug) | gotchas #9 |
 
 Plus efficiency measurements: **batch vs sequential** round-trips/time, and **`snapshot -i` vs full**
-output size (token-discipline proxy).
+output size (token-discipline proxy). And a **PDF-template scoped-read drift gate** (pure file, no
+browser): asserts a scoped Read of the `<script>` block still saves ≥40% vs the whole template, so a
+CSS refactor that weakens the saving documented in `references/pdf-reports.md` fails here.
 
 ## PDF pagination test (`pdf/pdf-test.sh`)
 

--- a/self-test/smoke-test.sh
+++ b/self-test/smoke-test.sh
@@ -62,6 +62,18 @@ echo "  sequential: 5 CLI calls, $(awk "BEGIN{printf \"%.2f\", $t1-$t0}")s | bat
 echo "=== EFFICIENCY: output size snapshot(full) vs snapshot -i (token proxy) ==="
 echo "  snapshot full: $(ab snapshot | wc -c) bytes | snapshot -i: $(ab snapshot -i | wc -c) bytes"
 
+echo "=== EFFICIENCY: PDF template scoped-read drift gate (pure file, no browser) ==="
+# pdf-reports.md tells you to Read only the <script> block when editing data[]. If a refactor
+# shrinks the CSS the saving weakens -> this gate flags it. Assert the scoped read still saves >=40%.
+ROOT="$(dirname "$HERE")"
+for f in guide-template bug-report-template; do
+  file="$ROOT/assets/$f.html"
+  sline=$(grep -nE '^<script>$' "$file" | head -1 | cut -d: -f1)
+  full=$(wc -c < "$file"); block=$(tail -n +"$sline" "$file" | wc -c); saved=$(( (full-block)*100/full ))
+  echo "  $f: full=${full}c block(<script>@L$sline)=${block}c -> scoped read saves ${saved}%"
+  chk "$f scoped-read saves >=40%" "yes" "$([ "$saved" -ge 40 ] && echo yes || echo no)"
+done
+
 echo "=== cleanup ==="
 ab close >/dev/null
 echo ""


### PR DESCRIPTION
อัปเดต ledger + harness ให้ตรงกับ 5 PR ที่ merge (#2,#4,#8,#9,#10)

- **CLAIMS-AUDIT Round 3 (2026-07-17):** ลง 2 claim ใหม่ — NetSuite networkidle (causal, cross-ref, ไม่ได้ A/B ที่นี่ → MED) + scoped-read saving (measured tiktoken 53/54% → LOW, มี gate)
- แก้ line-ref ที่ drift: L23/L30/L54 → L32/L41/L67
- **smoke-test.sh:** drift gate แบบ pure-file (template `<script>` block ≥40% เล็กกว่าไฟล์เต็ม) — รันได้โดยไม่ง้อ agent-browser, verified 2/2 pass
- self-test/README.md: บันทึก gate ใหม่

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)