### PR TITLE
feat(release): ออก GitHub Release เองตอน push tag (#36)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,46 @@
+# release.yml — tag ต้องมี GitHub Release คู่กันเสมอ (Playbook R7 ของ Teibto/teibto-dev-standards)
+#
+# `git push --tags` สร้างแค่ tag ส่วน Release เป็นคนละ object ที่ต้องสร้างแยก ถ้าปล่อยเป็นงานมือ
+# จะหลุดเงียบข้าม release (repo มาตรฐานเองหลุดไป 20 tag จนหน้า Releases ค้างอยู่หลายเวอร์ชัน)
+#
+# ★ repo นี้ไม่เคยมี CI มาก่อน — workflow นี้ทำ **เฉพาะ release-on-tag** ไม่ได้เพิ่ม quality-gate
+#   (secret-scan / shellcheck / self-test) เพราะเป็นคนละการตัดสินใจ ถ้าจะเพิ่มให้เปิด issue แยก
+# ★ ต้อง build + แนบ `.skill` bundle ด้วย — flow มือเดิมแนบมาตลอด ถ้า automate แล้วลืมข้อนี้
+#   bundle จะหายเงียบ ๆ และคนที่ install แบบ one-file จะโหลดไม่ได้
+# @author Wichit Wongta @since 2026-08-04
+
+name: release
+
+on:
+  push:
+    tags: ["v*"]
+
+jobs:
+  release:
+    name: publish-release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # default token เป็น read-only สร้าง Release ไม่ได้
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0 # ต้องมี tag ครบ — สคริปต์ verify ว่า tag มีจริงก่อนสร้าง
+
+      # build-skill.py ใช้แค่ stdlib (glob/os/zipfile) จึงรันบน runner ได้ตรง ๆ
+      # `.skill` ไม่ถูก commit โดยเจตนา (มันซ้ำกับ source และค้างง่าย) — build ใหม่ทุก release
+      - name: Build .skill bundle
+        run: python3 scripts/build-skill.py
+
+      # สคริปต์ idempotent: มี Release อยู่แล้ว = SKIP ไม่เขียนทับ (re-run workflow ได้ปลอดภัย)
+      # badge Latest ไปตามเลขเวอร์ชัน ไม่ใช่ลำดับที่สร้าง
+      - name: Create GitHub Release from CHANGELOG
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bash scripts/publish-release.sh "${GITHUB_REF_NAME}"
+
+      # แยกขั้นเพราะ publish-release.sh เป็น asset กลางที่ใช้ร่วมหลาย repo — ไม่ใส่ logic
+      # เฉพาะ repo นี้ลงไปในนั้น · --clobber ทำให้ re-run ทับไฟล์เดิมได้ไม่ error
+      - name: Attach .skill bundle to the release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload "${GITHUB_REF_NAME}" agent-browser-qa.skill --clobber

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,83 @@
+# Changelog
+
+รูปแบบตาม [Keep a Changelog](https://keepachangelog.com/) · วันที่ `YYYY-MM-DD` · เวอร์ชัน SemVer ต่อ repo
+
+> **ที่มาของไฟล์นี้:** repo นี้เขียน release note ด้วยมือมาตลอด (v1.0.0–v1.5.0) · ไฟล์นี้เพิ่มเข้ามา
+> ตอน 2026-08-04 เพื่อให้ CI ออก GitHub Release เองตอน push tag ตาม Playbook R7 ของทีม ·
+> **เนื้อเต็มของ v1.0.0–v1.4.0 อยู่ที่ [หน้า Releases](https://github.com/wichtking/agent-browser-qa/releases)**
+> ไม่ได้ copy มาซ้ำที่นี่ เพราะจะกลายเป็นสองแหล่งที่ drift จากกันได้ · ตั้งแต่ v1.6.0 เป็นต้นไป
+> ไฟล์นี้คือต้นฉบับ และ Release body ถูก generate จากมัน
+
+## [1.5.1] - 2026-08-04
+
+**ออก GitHub Release เองตอน push tag — เลิกทำมือ**
+
+### Added
+
+- **`CHANGELOG.md`** (ไฟล์นี้) + **`.github/workflows/release.yml`** + vendor
+  `scripts/publish-release.sh` จาก `Teibto/teibto-dev-standards` — tag ต้องมี Release object
+  คู่กันเสมอตาม Playbook R7 · repo นี้ยังไม่มีปัญหา (tag/release ตรงกัน 6/6) แต่ที่ตรงเพราะทำมือ
+  ทุกครั้ง งานนี้จึงกันไม่ให้ drift ไม่ใช่แก้ของที่พังอยู่ (#36)
+- workflow **build + แนบ `.skill` bundle** ให้ด้วย — flow มือเดิมแนบมาตลอด ถ้า automate แล้ว
+  ลืมข้อนี้ bundle จะหายเงียบ ๆ และคนที่ install แบบ one-file จะโหลดไม่ได้
+
+### Changed
+
+- `CONTRIBUTING.md` §Cutting a release — ขั้นตอนเหลือ "เขียน CHANGELOG entry แล้ว tag+push"
+  · **ไม่มี entry = workflow ล้มโดยเจตนา** (Release ที่ body ว่างแย่กว่าไม่มี)
+- ชื่อ Release เป็น `vX.Y.Z` เฉย ๆ ตามมาตรฐานทีม — คำบรรยายย้ายไปอยู่บรรทัดแรกของ body แทน
+
+## [1.5.0] - 2026-08-02
+
+**Transport ย้ายเป็น CDP ตรง — เลิกใช้ `agent-browser` daemon**
+
+daemon ค้างแบบไม่บอกเหตุ (`os error 10060` วนซ้ำ, Chrome ตายเงียบ) และตอบ JS dialog ไม่ได้เลย
+โดยเฉพาะ `beforeunload` ที่ทำให้ wedge ถาวร · ขับ Chrome ผ่าน CDP ตรงด้วย `cdp.py` ซึ่งเป็น
+driver กลางของทีมที่ [`Teibto/teibto-dev-standards`](https://github.com/Teibto/teibto-dev-standards)
+
+### Changed
+
+- `references/commands.md` เขียนใหม่ทั้งไฟล์ — คู่มือ `cdp.py` + ตารางแปลงคำสั่งเดิมครบทุกตัว
+- `references/gotchas.md` คัดของ daemon ออก (10060 ทุกสายพันธุ์, session file, batch shape,
+  record/ffmpeg, dashboard) เก็บของ Chrome/หน้าเว็บไว้ครบ + เพิ่ม 4 ข้อใหม่
+- `SKILL.md` golden rules 5 ข้อใหม่ (เดิมครึ่งหนึ่งเป็นเรื่อง daemon ล้วน)
+- `docs/ARCHITECTURE.md` เปลี่ยนภาพ transport + เพิ่ม §ที่ตัดออกและทำไม
+- `self-test/smoke-test.sh` เขียนใหม่ — launch Chrome เอง, **30 เคสกับ browser จริง (30/30 ผ่าน)**
+
+### Added
+
+- gotcha ใหม่ 4 ข้อจากที่เจอตอนย้ายจริง: `console` ว่าง ≠ ไม่มี error (หน้าที่ไม่ได้เปิดด้วย `nav`
+  จะ error ไม่ใช่คืน `[]`) · dialog ถูกตอบอัตโนมัติ = เปลี่ยนข้อมูลจริงได้ · `viewport` ที่สั่งแยก
+  invocation ไม่มีผลเพราะ Emulation ตายพร้อม websocket · element-scoped `shot` ตก top-layer popup
+
+### Removed
+
+- `record` / `stream` / `dashboard` (วิดีโอ + ดูสด) — เป็นฟีเจอร์ของ daemon · CDP ตรงทำได้แต่ต้อง
+  เขียน `Page.startScreencast` + ต่อเฟรมเป็นวิดีโอเอง ไม่คุ้มกับที่ pipeline ทำเอกสารใช้ screenshot
+  ต่อ step อยู่แล้ว · เหตุผลและทางกลับบันทึกไว้ใน `docs/ARCHITECTURE.md`
+- `references/video-and-live.md`
+
+## [1.4.0] - 2026-07-17
+
+**agent-browser 0.32.1 baseline + onboarding docs** —
+[เนื้อเต็ม](https://github.com/wichtking/agent-browser-qa/releases/tag/v1.4.0)
+
+## [1.3.0] - 2026-07-17
+
+**token optimization, parallel-terminal safety, release badge** —
+[เนื้อเต็ม](https://github.com/wichtking/agent-browser-qa/releases/tag/v1.3.0)
+
+## [1.2.0] - 2026-07-09
+
+**enforceable QA gate + test-data + a11y/perf/visual layers** —
+[เนื้อเต็ม](https://github.com/wichtking/agent-browser-qa/releases/tag/v1.2.0)
+
+## [1.1.0] - 2026-07-07
+
+**test design, flow specs, English docs** —
+[เนื้อเต็ม](https://github.com/wichtking/agent-browser-qa/releases/tag/v1.1.0)
+
+## [1.0.0] - 2026-06-25
+
+**agent-browser-qa — release แรก** —
+[เนื้อเต็ม](https://github.com/wichtking/agent-browser-qa/releases/tag/v1.0.0)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,13 +73,21 @@ Re-run after any Chrome or `cdp.py` version bump — this is the drift detector.
 ## Cutting a release
 
 1. Land all changes on `main` via PRs.
-2. `python scripts/build-skill.py` — rebuild `agent-browser-qa.skill`.
-3. Tag + release, attaching the bundle (SemVer; docs/optimization = minor, fixes = patch):
+2. Add a `## [X.Y.Z] - YYYY-MM-DD` section to `CHANGELOG.md`, leading with a **bold one-line
+   summary** (it becomes the first line of the release body).
+3. Tag and push — that's it (SemVer; docs/optimization = minor, fixes = patch):
    ```bash
-   gh release create vX.Y.Z --target main --title "vX.Y.Z — <summary>" \
-     --notes "<what changed>" agent-browser-qa.skill
+   git tag -a vX.Y.Z -m "vX.Y.Z — <summary>" && git push origin vX.Y.Z
    ```
-   The README's release badge is dynamic and updates itself once the release is the latest.
+   `.github/workflows/release.yml` then builds `agent-browser-qa.skill`, creates the GitHub
+   Release with the body taken from that CHANGELOG section, and attaches the bundle.
+
+**No CHANGELOG entry = the workflow fails on purpose** — a release with an empty body is worse
+than no release.
+
+The release title is plain `vX.Y.Z` (team standard, `Teibto/teibto-dev-standards` Playbook R7);
+the descriptive summary now lives in the first line of the body instead of the title.
+The README's release badge is dynamic and updates itself once the release is the latest.
 
 ## Git flow
 

--- a/scripts/publish-release.sh
+++ b/scripts/publish-release.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# publish-release.sh — สร้าง GitHub Release ของ tag หนึ่งตัว โดยดึงเนื้อจาก CHANGELOG.md (#113)
+#
+# ทำไมต้องมี: `git push origin <tag>` สร้าง **tag** เท่านั้น · หน้า Releases แสดงเฉพาะ
+# **Release object** ซึ่งต้องสร้างแยก — เป็นงานมือที่ไม่มีอะไรสั่งให้ทำ จึงหลุดเงียบข้าม release
+# มาแล้ว 20 tag (หน้า Releases ค้างที่ v0.33.0 ทั้งที่ tag ไปถึง v0.39.0)
+#
+# ใช้:
+#   bash scripts/publish-release.sh v0.39.0            # สร้างจริง (ข้ามถ้ามีอยู่แล้ว)
+#   bash scripts/publish-release.sh v0.39.0 --dry-run  # พิมพ์ body ที่จะใช้ ไม่แตะ GitHub
+#
+# ★ idempotent โดยเจตนา — CI เรียกทุกครั้งที่ push tag และ backfill ก็ใช้สคริปต์ตัวเดียวกัน
+#   รันซ้ำต้องไม่พังและต้องไม่เขียนทับของเดิม
+# ★ ต้องมี gh ที่ auth แล้ว (local) หรือ GH_TOKEN ใน env (CI)
+# @author Wichit Wongta @since 2026-08-02
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CHANGELOG="${ROOT}/CHANGELOG.md"
+
+TAG=""
+DRY=0
+for a in "$@"; do
+  case "$a" in
+    --dry-run) DRY=1 ;;
+    -h|--help) sed -n '2,16p' "$0"; exit 0 ;;
+    v*) TAG="$a" ;;
+    *) echo "FATAL: unknown arg '$a' (ใช้: <vX.Y.Z> [--dry-run])" >&2; exit 2 ;;
+  esac
+done
+[ -n "${TAG}" ] || { echo "FATAL: ต้องระบุ tag เช่น v0.39.0" >&2; exit 2; }
+[ -f "${CHANGELOG}" ] || { echo "FATAL: ไม่พบ ${CHANGELOG}" >&2; exit 1; }
+
+# เลือก interpreter จากการ **รันจริง** — Windows วาง App Execution Alias `python3` ที่มีอยู่ใน PATH
+# แต่รันแล้วเด้ง Microsoft Store + exit 49 · `command -v` จึงหลอกได้ (บทเรียน #107)
+PY=""
+for cand in python3 python py; do
+  if "$cand" -c 'import sys' >/dev/null 2>&1; then PY="$cand"; break; fi
+done
+[ -n "${PY}" ] || { echo "FATAL: ต้องมี python3 (หรือ python) ที่รันได้จริงใน PATH" >&2; exit 1; }
+export PYTHONIOENCODING=utf-8
+
+# ---- ดึงเนื้อของเวอร์ชันนี้จาก CHANGELOG ----
+# ตัดตั้งแต่บรรทัด `## [X.Y.Z]` จนถึงก่อน `## [` ตัวถัดไป — **ต้องหยุดที่หัวข้อถัดไป**
+# ไม่งั้นจะกิน release เก่าทั้งไฟล์มาเป็น body (เทส T2 กันข้อนี้)
+BODY="$(VERSION="${TAG#v}" "${PY}" - "${CHANGELOG}" <<'PYEOF'
+import io, os, re, sys
+ver = os.environ["VERSION"]
+text = io.open(sys.argv[1], encoding="utf-8").read()
+m = re.search(r"^## \[%s\][^\n]*\n(.*?)(?=^## \[|\Z)" % re.escape(ver), text, re.S | re.M)
+sys.stdout.write(m.group(1).strip() if m else "")
+PYEOF
+)"
+
+if [ -z "${BODY}" ]; then
+  echo "FATAL: ไม่พบหัวข้อ '## [${TAG#v}]' ใน CHANGELOG.md — เพิ่ม entry ก่อนแล้วค่อย tag" >&2
+  exit 1
+fi
+
+# ---- badge Latest ต้องอยู่กับเลขเวอร์ชันสูงสุด ไม่ใช่ตัวที่สร้างล่าสุด ----
+# `gh release create` default เป็น make_latest=legacy ซึ่ง GitHub ตีความว่า "Release ที่สร้าง
+# ล่าสุดตามเวลา" → backfill tag เก่าไปแย่ง badge จากเวอร์ชันปัจจุบัน (เจอจริงตอน backfill #113:
+# v0.39.0 แย่ง Latest จาก v0.40.0) · จึงระบุให้ชัดเจนทุกครั้ง ไม่ปล่อยให้ลำดับการรันตัดสิน
+# ★ `git -C "${ROOT}"` ไม่ใช่ git เฉย ๆ — สคริปต์อ่าน CHANGELOG จาก ROOT อยู่แล้ว tag ก็ต้องมาจาก
+#   repo เดียวกัน ไม่ใช่จาก cwd ที่บังเอิญเรียก (ไม่งั้นเรียกข้าม repo แล้วได้ผลมั่ว)
+HIGHEST="$(git -C "${ROOT}" tag --list 'v*' --sort=v:refname | tail -1)"
+LATEST_FLAG="--latest=false"
+[ "${TAG}" = "${HIGHEST}" ] && LATEST_FLAG="--latest"
+
+if [ "${DRY}" -eq 1 ]; then
+  printf '=== %s (%s · สูงสุดใน repo = %s) ===\n%s\n' \
+    "${TAG}" "${LATEST_FLAG}" "${HIGHEST:-<ไม่มี tag>}" "${BODY}"
+  exit 0
+fi
+
+# ---- สร้างจริง ----
+command -v gh >/dev/null 2>&1 || { echo "FATAL: ต้องมี gh CLI" >&2; exit 1; }
+
+if gh release view "${TAG}" >/dev/null 2>&1; then
+  echo "SKIP: Release ${TAG} มีอยู่แล้ว — ไม่เขียนทับ"
+  exit 0
+fi
+if ! git -C "${ROOT}" rev-parse -q --verify "refs/tags/${TAG}" >/dev/null; then
+  echo "FATAL: ยังไม่มี tag ${TAG} ใน repo — tag ก่อนแล้วค่อยสั่ง" >&2
+  exit 1
+fi
+
+printf '%s\n' "${BODY}" | gh release create "${TAG}" --title "${TAG}" "${LATEST_FLAG}" --notes-file -
+echo "CREATED: Release ${TAG} (${LATEST_FLAG})"


### PR DESCRIPTION
@
Closes #36

## ทำไม (และทำไมตอนนี้ไม่ได้พังอยู่)

Playbook R7 ของทีมระบุว่า **tag ต้องมี GitHub Release object คู่กันเสมอ และให้ CI สร้างจาก
`CHANGELOG.md` ตอน push tag** — `git push --tags` สร้างแค่ tag ส่วน Release ต้องสร้างแยก
ซึ่งเป็นงานมือที่ไม่มีอะไรสั่งให้ทำ (repo มาตรฐานเองหลุดไป **20 tag**)

repo นี้ **ยังไม่มีปัญหา — tag กับ release ตรงกันครบ 6/6** แต่ที่ตรงเพราะทำมือทุกครั้ง ·
**งานนี้กันไม่ให้ drift ไม่ใช่แก้ของที่พังอยู่**

## เพิ่มอะไร

| ไฟล์ | สาระ |
|---|---|
| `CHANGELOG.md` (ใหม่) | entry เต็มของ `v1.5.0` + สรุปบรรทัดเดียวของ `v1.0.0`–`v1.4.0` พร้อมลิงก์ไปหน้า Releases |
| `.github/workflows/release.yml` (ใหม่) | build bundle → สร้าง Release จาก CHANGELOG → แนบ bundle |
| `scripts/publish-release.sh` | vendor จาก `teibto-dev-standards` — **asset กลาง ห้ามแก้ที่นี่** |
| `CONTRIBUTING.md` | §Cutting a release เขียนใหม่ตาม flow ใหม่ |

## สองข้อที่เกือบพลาด

**1. `.skill` bundle เกือบหาย** — flow มือเดิมแนบ `agent-browser-qa.skill` ไปกับทุก release
(README บอกให้โหลดไฟล์เดียวไปติดตั้ง) · ถ้า automate แค่ "สร้าง Release จาก CHANGELOG" bundle
จะหายเงียบ ๆ และคนที่ install แบบ one-file จะโหลดไม่ได้ → workflow มีขั้น build + upload ด้วย

`build-skill.py` ใช้แค่ stdlib (`glob`/`os`/`zipfile`) จึงรันบน runner ได้ตรง ๆ —
build ทดสอบในเครื่องแล้วได้ **63,958 bytes**

**2. ไม่ copy release body เก่ามาซ้ำ** — 5 release เก่ารวมกัน ~10KB · ถ้าลอกมาใส่ CHANGELOG
จะกลายเป็นสองแหล่งที่ drift จากกันได้ → ใส่สรุปบรรทัดเดียว + ลิงก์ไปของจริงแทน และเขียนกำกับ
ไว้ที่หัวไฟล์ว่า **ตั้งแต่ v1.6.0 เป็นต้นไป CHANGELOG คือต้นฉบับ**

## ขอบเขตที่จงใจไม่ทำ

repo นี้**ไม่เคยมี CI มาก่อน** · workflow นี้ทำ **เฉพาะ release-on-tag** ไม่ได้เพิ่ม
quality-gate (secret-scan / shellcheck / `self-test/smoke-test.sh`) เพราะเป็นคนละการตัดสินใจ —
ถ้าจะเพิ่มควรเปิด issue แยกและคุยเรื่อง runner ก่อน

## trade-off

ชื่อ Release จะเป็น `vX.Y.Z` เฉย ๆ ตามมาตรฐานทีม **ไม่ใช่ชื่อบรรยาย**แบบเดิม
(`v1.4.0 — agent-browser 0.32.1 baseline + onboarding docs`) · ชดเชยด้วยการให้ทุก section
ใน CHANGELOG ขึ้นต้นด้วย**บรรทัดสรุปตัวหนา** เพื่อให้ body ของ Release นำด้วยสาระเหมือนเดิม

## หลักฐาน

```
$ bash scripts/publish-release.sh v1.5.0 --dry-run
=== v1.5.0 (--latest · สูงสุดใน repo = v1.5.0) ===        ← badge ถูก
**Transport ย้ายเป็น CDP ตรง — เลิกใช้ agent-browser daemon**   ← body นำด้วยสรุป

$ bash scripts/publish-release.sh v1.4.0 --dry-run
=== v1.4.0 (--latest=false · สูงสุดใน repo = v1.5.0) ===  ← tag เก่าไม่แย่ง badge

$ py scripts/build-skill.py   → agent-browser-qa.skill 63,958 bytes (gitignored ✓)
$ shellcheck --severity=error scripts/publish-release.sh   → PASS
YAML: steps = [checkout, Build .skill bundle, Create GitHub Release, Attach bundle]
```

หลัง merge จะ tag `v1.5.1` แล้วดูว่า Release โผล่เองพร้อม bundle และ badge ถูกต้อง

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@