### PR TITLE
docs: เก็บบทเรียนที่ค้าง + เอกสารตามทันคำสั่งใหม่ + แก้ที่สอนคำสั่งยุค daemon (#41, #40)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,42 @@
 > ไม่ได้ copy มาซ้ำที่นี่ เพราะจะกลายเป็นสองแหล่งที่ drift จากกันได้ · ตั้งแต่ v1.6.0 เป็นต้นไป
 > ไฟล์นี้คือต้นฉบับ และ Release body ถูก generate จากมัน
 
+## [1.6.1] - 2026-08-16
+
+**เก็บงานค้างให้จบ — บทเรียนที่ไม่เคยเข้า repo และเอกสารที่ยังสอนคำสั่งที่ไม่มีอยู่จริง**
+
+### Added
+
+- **บทเรียน 7 ข้อที่เขียนไว้ตั้งแต่ 2026-08-10 แต่ไม่เคย commit** — `gotchas.md` §11–§17
+  (`nav` อาร์กิวเมนต์ที่สองเป็นวินาที · Chrome บังคับหน้าต่างกว้างขั้นต่ำ ~500px · อ่าน state ทันที
+  หลัง scroll · custom property ค้าง · `innerWidth` รวม scrollbar · `el.focus()` ไม่ปลุก
+  `:focus-visible` · Chrome cache หน้าเดิม) และหมายเหตุ path Windows ของ `shot`/`pdf` ใน
+  `commands.md` · v1.6.0 อ้าง §14–§17 ทั้งที่ยังไม่มีอยู่บน main — คนที่ clone ไปตามลิงก์เจอความว่าง (#41)
+- **`commands.md` §`run` และ §`lens`/`steady`/`netlog`/`stub`** — ตารางว่าตัวไหนต้องอยู่ในโหมด `run`
+  + กับดัก quote ของ `--body=` + `verdict` มีสามค่าไม่ใช่สอง
+- **`self-test/smoke-test.sh` เพิ่ม claim-check ของคำสั่งใหม่** — `run` ทำให้ override อยู่ข้ามคำสั่ง
+  (พร้อม**เคสคู่**ที่พิสูจน์ว่าเทสวัดของจริง) · `lens layout` FAIL บนหน้าที่ผิดและ PASS บนหน้าที่ถูก ·
+  **`lens netlog` ที่ไม่ได้ `netlog on` = `UNVERIFIED`** — claim ที่อันตรายที่สุดของทั้งสกิล
+  เพราะถ้ามัน regress ผลจะออกมาเป็นสีเขียวโดยไม่มีอะไรฟ้อง
+
+### Fixed
+
+- **`docs/ARCHITECTURE.md` §3 ยังเป็นชั้น QA ยุค daemon** — ตารางสอนคำสั่งที่ไม่มีอยู่จริงแล้ว
+  (`open`, `errors`, `diff screenshot --baseline`) และนับ 4 ชั้นขณะที่ README/SKILL.md นับ 7 ·
+  เขียนใหม่ทั้งหัวข้อ + diagram ที่แยกชั้นบังคับกับชั้น opt-in (#40)
+- **README สอนสิ่งที่ไม่จริงสองจุด** — "`click` does not auto-scroll, so call `scrollintoview` first"
+  (ปัจจุบัน `click` ทำ `scrollIntoView` ให้ในตัว) และคำแนะนำให้ล้าง "stale session file" ตอนเจอ
+  `os error 10060` (เป็นวิธีของ daemon ที่ไม่มีอยู่แล้ว) · ตารางงานในหน้าแรกก็ยังเป็นคำสั่งยุค daemon ทั้งตาราง
+- เลิกเขียนจำนวนเคสของ `smoke-test.sh` เป็นตัวเลขตายตัวใน README — สคริปต์พิมพ์ผลรวมเอง
+  ป้ายที่ hardcode จะ drift ทุกครั้งที่เพิ่มเทส
+- `CLAUDE.md` / `README.md` รายชื่อไฟล์ใน `references/` ตามทัน `ux-lens` · `cdp-limits` · `configure`
+
+### Changed
+
+- **CLAIMS-AUDIT: ตัดสินใจเรื่องการแบ่งเทสระหว่างสองรีโป** — เทสลึกของ `cdp.py` อยู่ที่
+  `tests/test-cdp.sh` ของ `teibto-dev-standards` เท่านั้น **ไม่ mirror มาที่นี่** (สองแหล่งจะ drift
+  จากกัน) · repo นี้เก็บเฉพาะ claim-check ของสิ่งที่สกิลนี้สัญญาเอง
+
 ## [1.6.0] - 2026-08-16
 
 **ชั้นที่ 7: UX/UI lens — และเส้นแบ่งระหว่างงาน QA กับงานตั้งค่าระบบ**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ Two consequences to keep in mind when editing:
 | Path | What it is |
 |---|---|
 | `SKILL.md` | The skill itself: golden rules, workflow, targets. Loaded every trigger. |
-| `references/` | Thai working notes: `gotchas`, `commands`, `test-design`, `flow-spec`, `pdf-reports`, `coverage-model`, `reliability-policy`, `a11y-layer`, `perf-layer`, `visual-regression`, `test-data`. On-demand. |
+| `references/` | Thai working notes: `gotchas`, `commands`, `test-design`, `flow-spec`, `pdf-reports`, `coverage-model`, `reliability-policy`, `a11y-layer`, `perf-layer`, `visual-regression`, `test-data`, `ux-lens`, `cdp-limits`, `configure`. On-demand. |
 | `docs/` | `ARCHITECTURE.md` (mermaid per flow), `TEAM-PROCESS.md` (lifecycle, release gate, RACI), `CLAIMS-AUDIT.md` (claim ledger). |
 | `assets/` | PDF templates (`guide-`, `bug-report-template.html`) + `highlight.js` / `pointer.js`. Edit only the `data[]` block — see `references/pdf-reports.md`. |
 | `self-test/` | `smoke-test.sh` (claim checks กับ Chrome จริงผ่าน cdp.py) + `pdf/pdf-test.sh` (pagination A/B). |

--- a/README.md
+++ b/README.md
@@ -38,14 +38,16 @@ Full diagrams for every flow are in [`docs/ARCHITECTURE.md`](./docs/ARCHITECTURE
 
 | Flow | Steps | Output |
 |---|---|---|
-| Smoke QA | `open` → `wait --load networkidle` → walk happy path → `errors` empty | pass / fail |
-| Functional QA | action → `scrollintoview` → `click` → assert state | verdict per step |
-| Visual regression | `screenshot` → `diff screenshot --baseline` | `diff.png` |
-| Error surfacing | after every key step → `errors --json` + `console --json` | errors surface, not silent |
+| Smoke QA | `nav` → `wait "<page-specific condition>"` → walk happy path → `console` empty | pass / fail |
+| Functional QA | action → `click` / `fill` → assert state with `get` / `is` / `wait` | verdict per step |
+| Visual regression | `steady` → `shot` → `diff <baseline> <current>` | `diff.png` |
+| Error surfacing | `console` after every key step, `lens netlog` for the network layer | errors surface, not silent |
+| UX/UI review | `lens layout` · `responsive` · `theme` · `focus` | findings only, `[]` means clean |
+| Empty / error screens | `run` a script with `stub <url> <status>` | the state you cannot reach with real data |
 | User-guide PDF | walk flow, highlight, screenshot → `guide-template.html` → `pdf` | guide PDF (cover, TOC, page numbers) |
 | Bug-report PDF | repro, evidence, severity → `bug-report-template.html` → `pdf` | bug PDF (Steps/Expected/Actual) |
 
-Golden rule: `click` does not auto-scroll, so call `scrollintoview` first; and don't trust `✓ Done`, always assert the resulting state. Details in [`references/gotchas.md`](references/gotchas.md).
+Golden rule: a command that exits 0 only means it was *sent* — always assert the resulting state, and never read `UNVERIFIED` as a pass. Details in [`references/gotchas.md`](references/gotchas.md).
 
 ## Features
 
@@ -110,7 +112,7 @@ AB shot hello.png          # evidence file: the image, not context
 
 Expect the title to contain `Example Domain` and `console` to print `[]`. If `console` **errors** instead of printing `[]`, the page was not opened with `nav`, so nothing is watching — that distinction is deliberate (see [`references/gotchas.md`](references/gotchas.md) #2).
 
-The first run is slow: a cold browser session can take one to two minutes to start on Windows, and may look like it hung when it hasn't. Keep the session warm and reuse it. If commands keep failing with `os error 10060`, clear the stale session file (see [`references/gotchas.md`](references/gotchas.md), section 3).
+Keep the Chrome you launched and reuse it — the profile directory holds the login, so a persistent one costs you the sign-in exactly once. If a command reports that the CDP port is not answering, Chrome died: check with `curl http://127.0.0.1:$CDP_PORT/json/version` and relaunch. There is no daemon and no session file to clear.
 
 For a real multi-step flow, see [`examples/saucedemo.yaml`](examples/saucedemo.yaml) and [`references/flow-spec.md`](references/flow-spec.md).
 
@@ -129,6 +131,9 @@ agent-browser-qa/
 │   ├── gotchas.md                 silent-failure traps and fixes
 │   ├── test-design.md             what to test (adversarial coverage, Phase 0-3)
 │   ├── commands.md                command reference, token discipline, batch
+│   ├── ux-lens.md                 layer 7: the lenses, and how each one can lie
+│   ├── cdp-limits.md              what CDP cannot check at all, and what to do instead
+│   ├── configure.md               changing real settings through the screen (not QA)
 │   ├── flow-spec.md               test cases as repeatable flow YAML
 │   └── pdf-reports.md             paged.js recipe (TOC, page numbers, fixes)
 ├── assets/
@@ -159,7 +164,7 @@ Python tooling (`pip install -r requirements.txt`, PyYAML):
 | `scripts/coverage-check.py` | Release gate → exit code: reads a `qa/<feature>/coverage.yaml`, returns 0 pass / 1 fail / 2 malformed. | `python scripts/coverage-check.py qa/<feature>/coverage.yaml` |
 | `scripts/release-summary.py` | Roll every `qa/*/coverage.yaml` into one QA-Lead sign-off table. | `python scripts/release-summary.py [qa_dir]` |
 
-Mechanical checks live in [`self-test/`](self-test) — run `bash self-test/smoke-test.sh` after any Chrome or `cdp.py` version bump (30 checks against a real browser). Details in [`CONTRIBUTING.md`](CONTRIBUTING.md).
+Mechanical checks live in [`self-test/`](self-test) — run `bash self-test/smoke-test.sh` after any Chrome or `cdp.py` version bump; it prints its own pass/fail count against a real browser. It checks the claims *this skill* makes; the driver's own suite (`tests/test-cdp.sh` in [`Teibto/teibto-dev-standards`](https://github.com/Teibto/teibto-dev-standards)) covers `cdp.py` itself, and the two are deliberately not mirrored. Details in [`CONTRIBUTING.md`](CONTRIBUTING.md).
 
 ## Glossary
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -6,7 +6,7 @@ Workflow diagrams for every flow. GitHub renders mermaid natively. A short summa
 ## Contents
 1. [Overview: one pass, two outputs](#1-overview-one-pass-two-outputs)
 2. [Golden-rule action loop](#2-golden-rule-action-loop)
-3. [Four QA layers](#3-four-qa-layers)
+3. [Seven QA layers](#3-seven-qa-layers)
 4. [PDF pipeline (paged.js)](#4-pdf-pipeline-pagedjs)
 5. [Highlight capture sub-flow](#5-highlight-capture-sub-flow)
 6. [Targets and setup](#6-targets-and-setup)
@@ -65,21 +65,38 @@ flowchart TD
 
 ---
 
-## 3. Four QA layers
+## 3. Seven QA layers
+
+Layers 1–4 run on every pass. Layers 5–7 are opt-in per scenario and return findings only — never a
+dump — so switching them on does not cost the context window.
 
 ```mermaid
 flowchart LR
-    s["1. Smoke<br/>happy path completes<br/>+ errors empty"] --> f["2. Functional<br/>assert state<br/>with short commands"]
-    f --> v["3. Visual<br/>diff screenshot<br/>--baseline"]
-    v --> e["4. Error surfacing<br/>errors/console<br/>after every key step"]
+    s["1. Smoke<br/>happy path completes<br/>+ console empty"] --> f["2. Functional<br/>assert state<br/>with short commands"]
+    f --> v["3. Visual<br/>diff baseline.png current.png"]
+    v --> e["4. Error surfacing<br/>console after<br/>every key step"]
+    e -.opt-in.-> a["5. a11y<br/>axe-core, count + top N"]
+    e -.opt-in.-> p["6. Perf<br/>save/load ms vs budget"]
+    e -.opt-in.-> u["7. UX/UI lens<br/>layout · responsive · theme<br/>focus · netlog"]
 ```
 
 | Layer | When | Main commands | Pass criteria |
 |---|---|---|---|
-| Smoke | every commit | `open`, `wait`, `errors` | flow completes, errors empty |
+| Smoke | every commit | `nav`, `wait`, `console` | flow completes, `console` empty |
 | Functional | key features | `is`, `get`, `wait` | state matches at every step |
-| Visual | UI changes | `diff screenshot --baseline` | diff within threshold |
-| Error surfacing | every key step | `errors --json`, `console --json` | errors surface, not swallowed |
+| Visual | UI changes | `steady` then `diff <base> <cur>` | diff within threshold |
+| Error surfacing | every key step | `console` | errors surface, not swallowed |
+| a11y | forms, new screens | `evalf` axe-core | count + top N within budget |
+| Perf | save/load paths | `eval` timing marks | under the scenario's ms budget |
+| UX/UI lens | responsive / theme / keyboard work | `lens layout\|responsive\|theme\|focus\|netlog` | `verdict: PASS` — and `UNVERIFIED` is **not** a pass |
+
+Two things the table cannot show:
+
+- **`console` empty ≠ no errors.** An app that catches its own failures leaves `console` clean while
+  the API returns 500. That class is only visible through `lens netlog`, which needs `netlog on`
+  inside a `run` — and returns `UNVERIFIED`, not `PASS`, when nobody was watching.
+- **Layer 7 needs a session that outlives one command** for `netlog`/`stub`, which is what `run`
+  provides. The rest of the lenses work in a single invocation.
 
 ---
 

--- a/docs/CLAIMS-AUDIT.md
+++ b/docs/CLAIMS-AUDIT.md
@@ -19,10 +19,15 @@ claim ที่ผูกกับ **Chrome/หน้าเว็บ** ยัง�
 | `console` ของหน้าไม่เห็น HTTP 4xx/5xx ที่แอป `catch` เอง — `lens netlog` เห็น | measured (เคสคู่ในเทสเดียวกัน) | LOW | T21b/T21c |
 | `Fetch.fulfillRequest` เปลี่ยนหน้าจอเข้าสถานะ empty/error ได้จริง | measured บน HTTP server จริงในเทส | LOW | T21f/T21h |
 
-**หนี้ที่ยังเหลือ:** `self-test/smoke-test.sh` ของ repo นี้ (30 เคส) ยังไม่ครอบคำสั่งชุดใหม่ —
-เคสทั้งหมดข้างบนอยู่ใน `tests/test-cdp.sh` ของ `teibto-dev-standards` ซึ่งเป็นเจ้าของ `cdp.py`
-· ตราบใดที่ยังไม่ตัดสินใจว่าจะ mirror เคสมาที่นี่หรืออ้างข้ามรีโป ให้ถือว่าคอลัมน์ Smoke ข้างบน
-หมายถึง "มีเทสที่ต้นทาง" ไม่ใช่ "มีเทสในรีโปนี้"
+**การแบ่งเทสระหว่างสองรีโป (ตัดสินใจ 2026-08-16):** `tests/test-cdp.sh` ของ `teibto-dev-standards`
+เป็นเจ้าของเทสลึกของ `cdp.py` — **ไม่ mirror มาที่นี่** เพราะจะกลายเป็นสองแหล่งที่ drift จากกัน
+(ปัญหาเดียวกับที่ CHANGELOG ของ repo นี้เคยเจอกับ Release body) · `self-test/smoke-test.sh`
+ของ repo นี้เก็บ **claim-check บาง ๆ ของสิ่งที่สกิลนี้สัญญาไว้** — ที่เพิ่มในรอบนี้: `run` ทำให้
+override อยู่ข้ามคำสั่งได้จริง (พร้อมเคสคู่), `lens layout` FAIL/PASS บนหน้าที่ผิด/ถูก,
+**`lens netlog` ที่ไม่ได้ `netlog on` = `UNVERIFIED`**, และ `steady` นอกโหมด `run` รายงาน `skipped`
+
+คอลัมน์ Smoke ข้างบนจึงหมายถึง "มีเทสที่ต้นทาง (`tests/test-cdp.sh`)" ส่วน claim ที่สกิลนี้เป็นคน
+สัญญาเองมีเทสของตัวเองใน `self-test/` แล้ว
 
 > **Round 4 (2026-07-17):** baseline re-verified on **agent-browser 0.32.1**. Two claims drifted —
 > below-fold `click` now auto-scrolls (rows #13, abq #1) and `batch --json` shape changed (row #10).

--- a/references/commands.md
+++ b/references/commands.md
@@ -96,6 +96,11 @@ AB wait "window.jQuery ? jQuery.active===0 : true" 20     # หน้า async �
 | `diff <baseline.png> <current.png> [out.png] [--threshold=N]` | visual regression · **exit 1 เมื่อต่าง** |
 | `pdf <path>` | Chrome printToPDF (traps → `pdf-reports.md`) |
 
+⚠️ **path ของ `shot`/`pdf` ต้องเป็น Windows-style (`cygpath -w`)** — ส่ง path แบบ Git-Bash
+(`/d/...`) ไฟล์**ไม่ถูกเขียนและคำสั่ง exit 0 ไม่ฟ้องอะไรเลย** (Windows Python ตีความ `/d/x`
+เป็น `<ไดรฟ์ปัจจุบัน>:\d\x`) · หลัง `shot` ให้ `ls` ยืนยันว่าไฟล์มีจริงก่อนอ้างเป็นหลักฐานเสมอ
+— เจอจริง 2026-08-10 (QA ar_aging บน SB2: รายงานเกือบอ้างภาพที่ไม่มีอยู่จริง)
+
 ⚠️ **`--dsf` ต้องส่งที่ `shot` ไม่ใช่สั่ง `viewport` แยกก่อน** — `Emulation.setDeviceMetricsOverride`
 ผูกกับ session ของ CDP และถูกยกเลิกทันทีที่ปิด websocket · `cdp.py` เปิด WebSocket ใหม่ทุกคำสั่ง
 แปลว่า `viewport 1920 1200 2` แล้วค่อย `shot` **ได้ภาพ 1x เสมอโดยไม่มีอะไรฟ้อง**

--- a/references/commands.md
+++ b/references/commands.md
@@ -138,6 +138,60 @@ AB eval "(function(){document.querySelector('SEL').size=window.__sz;return 'ok';
 ป๊อปอัป native ที่อยู่นอก DOM จริง ๆ (`alert`/`confirm`, file dialog) **screenshot ไม่ติดทุกกรณี** —
 ถ้าต้องเก็บภาพต้องใช้ OS-level capture (skill `netsuite-ui-qa-testing` มีสูตร)
 
+## `run` — หลายคำสั่งบน connection เดียว
+
+ทุก invocation เปิด WebSocket ใหม่ → **CDP override ตายก่อนคำสั่งถัดไปจะเริ่ม** · งานที่ต้องข้าม
+คำสั่ง (จอมือถือ, ธีม, timezone, ปลอมคำตอบ, เฝ้า network) จึงต้องอยู่ในโหมดนี้
+
+```bash
+cat > steps.txt <<'EOF'
+# หนึ่งคำสั่งต่อบรรทัด · '#' = คอมเมนต์
+netlog on
+steady --tz=Asia/Bangkok
+stub /api/orders 200 --bodyfile=D:\qa\empty.json
+nav https://app.example.com/orders 3
+lens layout
+lens netlog
+EOF
+AB run steps.txt
+```
+
+| กฎ | รายละเอียด |
+|---|---|
+| แยก argument แบบ shell | แต่ **backslash เป็นตัวอักษรธรรมดา** — path Windows ไม่ถูกกลืน |
+| ล้มบรรทัดไหน = หยุดทั้งสคริปต์ | บอกเลขบรรทัด + คำสั่ง ครอบทั้ง `SystemExit` และ exception อื่น |
+| **หนึ่ง `run` = หนึ่งแท็บ** | `tabs`/`newtab`/`close`/`diff` ถูกปฏิเสธ — แท็บถูกเลือกตอนต่อครั้งเดียว |
+| JSON ใน `--body=` | double quote โดน shlex กิน → ใช้ `--bodyfile=` หรือครอบ single quote |
+
+**ไม่ใช่ daemon:** lifetime ของ session = lifetime ของ process — จบสคริปต์คือจบ ไม่มี state ค้าง
+ไม่มี TTL ไม่มี orphan (เหตุผลที่ทีมทิ้ง `agent-browser` ยังใช้ได้อยู่)
+
+## `lens` / `steady` / `netlog` / `stub` — ชั้น UX/UI
+
+| คำสั่ง | คืนอะไร | ต้องอยู่ใน `run` |
+|---|---|---|
+| `lens layout` | ล้นแนวนอน · tap target < 24x24 · ข้อความถูกตัดหาย | ไม่ |
+| `lens responsive <w1,w2,..>` | วน `layout` ทุกความกว้าง + `no-viewport-meta` | ไม่ |
+| `lens theme` | ตัวหนังสือสีเดียวกับพื้น + `dark_mode: supported\|not-supported` | ไม่ |
+| `lens focus [n]` | ลำดับ Tab จริง · trap · ไม่มีเส้นบอกโฟกัส | ไม่ |
+| `lens netlog` | HTTP >= 400 · request ที่ล้ม · CSP/mixed content | **ใช่** |
+| `steady [--tz=] [--locale=]` | หยุด animation/transition/smooth scroll · `--tz`/`--locale` ต้องอยู่ใน `run` | บางส่วน |
+| `netlog on\|off` | เปิดเฝ้า `Network` + `Log` domain | **ใช่** |
+| `stub <urlที่ตรง> <status>` | ปลอมคำตอบเพื่อบังคับสถานะ empty/error | **ใช่** |
+
+```bash
+AB lens layout
+# {"lens":"layout","verdict":"FAIL","count":1,"findings":[
+#   {"kind":"tap-target-small","sel":"nav > a.menu","detail":"18x18 < 24x24 (WCAG 2.2 AA)"}]}
+```
+
+⚠️ **`verdict` มีสามค่า ไม่ใช่สอง** — `PASS` / `FAIL` / **`UNVERIFIED`** · `lens netlog` ที่ไม่ได้สั่ง
+`netlog on` มาก่อนคืน `UNVERIFIED` เพราะ "ไม่ได้เฝ้า" ไม่ใช่ "ไม่มีปัญหา" · คำสั่งที่ตั้ง override
+นอกโหมด `run` จะเตือนลง stderr เสมอว่าไม่มีผลจริง
+
+รายละเอียดการใช้งาน + ตารางว่าแต่ละ lens โกหกได้ยังไง → `ux-lens.md` ·
+สิ่งที่ CDP แตะไม่ได้เลย → `cdp-limits.md`
+
 ## ลด round-trip ในงานยาว
 
 ทุกคำสั่ง `cdp.py` = หนึ่ง process + หนึ่ง WebSocket handshake · flow ยาว ๆ ให้รวมงานเป็น

--- a/references/gotchas.md
+++ b/references/gotchas.md
@@ -22,6 +22,13 @@
 8. Chrome PDF viewer สคริปต์ไม่ได้
 9. headed window จอดำ — แยก 3 กลไก อย่าเหมารวมว่า "GPU"
 10. หลาย terminal ขับพร้อมกัน — แยก port + profile
+11. `nav <url> <n>` อาร์กิวเมนต์ที่สองเป็น "วินาที" ไม่ใช่เงื่อนไข JS
+12. Chrome บังคับหน้าต่างกว้างขั้นต่ำ ~500px — วัด layout ที่ 320/390 ตรง ๆ ไม่ได้
+13. อ่าน state ทันทีหลังสั่ง scroll = อ่านก่อน handler ที่ deferred ด้วย rAF ทำงาน
+14. เปลี่ยน CSS custom property แล้ววัดในสคริปต์เดียวกัน = ได้ค่า `var()` ค้าง (fail ปลอม)
+15. `innerWidth` ใต้ device-metrics override รวม scrollbar — ด่าน overflow จึงแดงทุกความกว้าง (fail ปลอม)
+16. `el.focus()` ไม่ทำให้ `:focus-visible` ทำงาน — ด่าน focus ring รายงานว่า "ทุกปุ่มไม่มี ring"
+17. Chrome cache หน้าเดิม — แก้ไฟล์แล้ว QA ยังวัดโค้ดเก่า ผลที่ได้จึงเป็นของรุ่นก่อนแก้
 
 ---
 
@@ -205,3 +212,161 @@ Get-CimInstance Win32_Process -Filter "Name='chrome.exe'" |
   ? { $_.CommandLine -like '*\.qa-profiles\*' } |
   % { Stop-Process -Id $_.ProcessId -Force }
 ```
+
+---
+
+## 11. `nav <url> <n>` อาร์กิวเมนต์ที่สองเป็น "วินาที" ไม่ใช่เงื่อนไข JS [LOW — แต่ทำ flow ตายตรงคำสั่งแรก]
+
+`AB nav "<url>" "document.readyState==='complete'"` **ไม่ใช่** syntax ที่มี — อาร์กิวเมนต์ที่สอง
+ของ `nav` คือจำนวนวินาทีที่ drain event เท่านั้น ส่งสตริงไปได้
+`ValueError: could not convert string to float` แล้ว flow ตายตรงนั้น (เจอจริง 2026-08-14)
+
+```bash
+AB nav "<url>" 3                                    # drain 3 วิ
+AB wait "document.readyState==='complete'" 15       # เงื่อนไขอยู่ที่ wait เท่านั้น
+```
+
+**ผลข้างเคียงที่แพงกว่าตัว error:** `nav` เป็นคำสั่งที่ติดตั้ง console collector ให้ · `nav` ล้ม =
+ไม่มี collector → `AB console` คำสั่งถัดไปตอบว่า "collector ยังไม่ถูกติดตั้ง" ซึ่ง**ถูก** แต่ถ้าอ่านผ่าน ๆ
+แล้วเข้าใจว่า "ไม่มี error" ก็คือ false pass ตาม gotcha #2 เต็มรูปแบบ
+
+---
+
+## 12. Chrome บังคับหน้าต่างกว้างขั้นต่ำ ~500px [MEDIUM — เงียบ · ทำให้เทส mobile เป็น false pass]
+
+`--window-size=320,900` **ไม่ได้ viewport 320** — Chrome (รวม `--headless=new`) ปัดขึ้นเป็น ~500px
+`window.innerWidth` จึงคืน 500 ทั้งที่สั่ง 320/390/480 → **เทส breakpoint ของมือถือผ่านโดยไม่ได้ทดสอบ
+ความกว้างจริงเลย** และไม่มีอะไรฟ้อง (เจอจริง 2026-08-14 · nav ล้นแนวนอนที่ 390px รอดด่านมาได้
+เพราะทุก probe วัดที่ 500)
+
+```bash
+for W in 320 390 480; do ... --window-size=$W,900 ...; done   # ทั้งสามได้ innerWidth=500
+```
+
+**ทางที่ใช้ได้จริง**
+
+| ต้องการ | ใช้ |
+|---|---|
+| ภาพที่ layout จริงของ 320/390 | `AB shot out.png --vw=390 --vh=844` (device metrics มีผลในคำสั่งนั้น ดู #4) |
+| assert ตัวเลข layout ที่ <500 | ไม่มีทางตรง — ยืนยันจากภาพ + assert ที่ 500 ซึ่งอยู่ใน media query เดียวกัน |
+| ตรวจว่าล้นแนวนอนไหม | assert `document.documentElement.scrollWidth === window.innerWidth` **และ**
+ไม่มี element ที่ `getBoundingClientRect().right > innerWidth` ที่ทุกความกว้างที่วัดได้ (500–1920) |
+
+**ห้ามใช้ `overflow-x:hidden` แก้อาการล้น** — มันทำให้ทั้งด่านนี้ผ่านฟรีตลอดไป (`scrollWidth`
+เท่ากับ `innerWidth` เสมอ) ทั้งที่ของยังล้นอยู่จริงและผู้ใช้เห็นของถูกตัด
+
+---
+
+## 13. อ่าน state ทันทีหลังสั่ง scroll = อ่านก่อน handler ที่ deferred ทำงาน [MEDIUM — false FAIL]
+
+หน้าเว็บที่ผูก `scroll` handler แล้ว defer งานด้วย `requestAnimationFrame` (แพตเทิร์นปกติของ
+scroll-spy / reveal / sticky state) **จะยังไม่ได้อัปเดต DOM ตอนที่สคริปต์ก้อนเดียวกันอ่านผล** —
+rAF callback รันหลัง script ปัจจุบันจบ
+
+```js
+// ❌ อ่านได้ NONE ทุกครั้ง ทั้งที่หน้าไม่ได้พัง
+document.getElementById('scale').scrollIntoView({behavior:'instant'});
+return document.querySelectorAll('a[aria-current]').length;
+```
+
+```bash
+# ✅ แยกเป็นสอง round trip — websocket ปิด/เปิดใหม่ให้เวลาเบราว์เซอร์ flush frame
+AB eval "document.getElementById('scale').scrollIntoView({behavior:'instant'}); 'x'"
+AB eval "[...document.querySelectorAll('a[aria-current]')].map(a=>a.getAttribute('href')).join('|')||'NONE'"
+```
+
+เจอจริง 2026-08-14: สรุปผิดว่า scroll-spy ไม่ทำงานเลย แล้วเกือบไปแก้โค้ดที่ถูกอยู่แล้ว ·
+**อาการเดียวกันกับ `behavior:'smooth'`** — ที่นั่นแย่กว่าเพราะ scroll ยังวิ่งอยู่ ตำแหน่งที่วัดได้
+เป็นของกลางทาง (ค่าติดลบแปลก ๆ) ใช้ `behavior:'instant'` เสมอเมื่อวัดตำแหน่ง
+
+---
+
+## 14. เปลี่ยน custom property แล้ววัดในสคริปต์เดียวกัน = ได้ค่าค้าง [HIGH — false FAIL ที่ดูน่าเชื่อ]
+
+สลับธีมด้วย `setAttribute('data-theme', ...)` (หรือแก้ `--token` ตรง ๆ) แล้วอ่าน
+`getComputedStyle` ของ element อื่นในสคริปต์ก้อนเดียวกัน จะได้ค่าที่ยัง resolve จากธีมก่อนหน้า
+Chrome resolve `var()` แบบ lazy ต่อ element — element ที่ถูกอ่านก่อน (เช่น `body`) recalc ให้
+แต่ element ที่อ่านทีหลังยังไม่ recalc
+
+```js
+// ❌ วัด contrast ได้ 1.06 (ตัวหนังสือหายไปกับพื้น) ทั้งที่ของจริง 17:1
+document.documentElement.setAttribute('data-theme','light');
+const s = getComputedStyle(document.querySelector('.btn-solid'));   // ยังเป็นสีของธีม dark
+```
+
+```bash
+# ✅ สลับใน round trip หนึ่ง วัดใน round trip ถัดไป
+AB eval "document.documentElement.setAttribute('data-theme','light');'set'"
+AB evalf contrast.js
+```
+
+**อาการที่ทำให้เสียเวลา:** ค่าที่ได้ "สมเหตุสมผล" พอที่จะเชื่อ — `body` อ่านได้สีใหม่ถูกต้อง
+แต่ปุ่มอ่านได้สีเก่า ทำให้สรุปว่า "ธีม light พังเฉพาะปุ่ม" แล้วไปไล่ specificity ของ CSS ที่ถูกอยู่แล้ว
+วิธียืนยันเร็วที่สุดคืออ่านค่าโทเคนกับค่าที่ element ใช้จริงมาเทียบกัน
+(`getComputedStyle(document.documentElement).getPropertyValue('--ink')` vs
+`getComputedStyle(el).backgroundColor`) ถ้าสองอันไม่ตรงกันคือเจอกับดักนี้ ไม่ใช่บั๊กของหน้า
+
+ญาติของ #13 — กฎเดียวกันคือ **หนึ่ง round trip เปลี่ยน หนึ่ง round trip วัด**
+
+**แก้เพิ่ม 2026-08-15: แยก round trip อย่างเดียว "ไม่พอ" เสมอไป** เจอเคสที่สลับธีมด้วย
+`setAttribute` ใน eval หนึ่ง แล้ว sleep 0.5 วินาที แล้ววัดใน eval ถัดไป **ยังได้สีของธีมเก่า**
+(ปุ่มอ่านได้ `#f2f2f0` ทั้งที่ `--ink` ของ `:root` อ่านได้ `#15171d` ถูกต้องแล้ว)
+สิ่งที่ได้ผลคือ **กดปุ่มสลับธีมของหน้าเองด้วย `.click()`** แล้วค่อยวัด เพราะ handler ของหน้า
+ทำงานในจังหวะที่เบราว์เซอร์ recalc ให้ครบ · กฎที่ปลอดภัยที่สุดคือ **เปลี่ยน state ผ่านทางที่ผู้ใช้
+ใช้จริง อย่าตั้ง attribute เองแล้ววัด** และยืนยันด้วย screenshot อย่างน้อยหนึ่งครั้งก่อนเชื่อว่าหน้าพัง
+
+---
+
+## 15. `innerWidth` ใต้ device-metrics override รวมความกว้าง scrollbar [HIGH — false FAIL ทุกความกว้าง]
+
+ด่าน "ไม่มีอะไรล้นแนวนอน" ที่เขียนว่า `documentElement.scrollWidth === innerWidth` **แดงทุกความกว้าง**
+เมื่อขับผ่าน `Emulation.setDeviceMetricsOverride` เพราะ `innerWidth` = ความกว้างที่สั่ง
+แต่ `scrollWidth`/`clientWidth` = ความกว้างหลังหัก scrollbar (~15px บน Windows)
+
+```js
+// ❌ 1265 !== 1280 ทุกครั้ง ทั้งที่ไม่มี element ไหนล้นเลย
+d.scrollWidth === innerWidth
+// ✅ เทียบกับ clientWidth และวัด element ทั้งสองข้าง
+d.scrollWidth <= d.clientWidth &&
+  ![...document.querySelectorAll('body *')].some(e => {
+    const b = e.getBoundingClientRect();
+    return b.right > d.clientWidth + 1 || b.left < -1;   // ล้นซ้ายไม่เพิ่ม scrollWidth
+  })
+```
+
+อาการที่หลอก: ความกว้างเล็ก ๆ ที่หน้าไม่มี scrollbar (เนื้อหาสั้น) จะผ่าน ส่วนความกว้างใหญ่แดงหมด
+ทำให้ดูเหมือน "layout พังเฉพาะจอใหญ่" ซึ่งเป็นข้อสรุปที่ผิด
+
+---
+
+## 16. `el.focus()` ไม่ทำให้ `:focus-visible` ทำงาน [HIGH — false FAIL ยกแผง]
+
+focus ring สมัยใหม่เขียนด้วย `*:focus-visible` ซึ่ง **ผูกกับ heuristic ว่าผู้ใช้ใช้คีย์บอร์ดอยู่**
+การเรียก `el.focus()` จากสคริปต์ไม่เข้าเงื่อนไขนั้น `getComputedStyle(el).outlineWidth` จึงเป็น `0px`
+ทุกตัว และด่านจะรายงานว่า "ทุกปุ่มไม่มี focus ring" ทั้งที่กด Tab เองแล้วเห็นชัด
+
+```bash
+# ✅ กด Tab จริงแล้ววัด document.activeElement ทีละ stop
+AB key Tab
+AB eval "(()=>{const e=document.activeElement,s=getComputedStyle(e);
+  return e.tagName+'|'+s.outlineWidth+'|'+s.outlineStyle;})()"
+```
+
+**และอย่าวัดแค่ความหนา** — `outlineWidth != 0` ผ่านได้ด้วย outline โปร่งใสหรือสีกลืนพื้น
+ต้องเช็ค `outlineStyle !== 'none'` · alpha ของ `outlineColor` · และ contrast กับพื้นหลัง ≥ 3:1
+
+---
+
+## 17. Chrome cache หน้าเดิมไว้ — QA วัดโค้ดที่ยังไม่ได้แก้ [HIGH — สรุปผิดว่า "แก้แล้วไม่หาย"]
+
+รอบ QA ที่แก้ไฟล์ใน working tree แล้ว `nav` ไป URL เดิม (`http://127.0.0.1:PORT/`)
+Chrome เสิร์ฟจาก memory cache ผลที่ได้จึงเป็นของรุ่นก่อนแก้ **อาการคือแก้บั๊กแล้วด่านยังแดงเหมือนเดิม
+เป๊ะทุกบรรทัด** ซึ่งชวนให้ไปรื้อโค้ดที่แก้ถูกแล้ว
+
+```python
+c.nav(URL + "?qa=" + str(int(time.time())))   # cache-bust ทุกรอบ
+```
+
+ตัวชี้ขาดว่าเจอกับดักนี้: เปิด URL พร้อม query ใหม่แล้วผลเปลี่ยนทันที · เจอจริง 2026-08-15
+(#117 ของ ERP-AI-First) เสียเวลาไปหนึ่งรอบเต็มกับการยืนยันว่า fix ที่ถูกอยู่แล้ว "ไม่ทำงาน"
+

--- a/self-test/smoke-test.sh
+++ b/self-test/smoke-test.sh
@@ -136,6 +136,38 @@ else
   echo "  SKIP  diff (ไม่มี pillow/numpy)"
 fi
 
+echo "=== run: override อยู่ข้ามคำสั่งได้จริง (claim ของ commands.md §run) ==="
+# ★ ตัวชี้วัดต้องเป็น devicePixelRatio ไม่ใช่ innerWidth — ขนาดหน้าต่างค้างข้าม invocation อยู่แล้ว
+#   ใช้ innerWidth เมื่อไหร่ เทสจะ "ผ่าน" ทั้งที่ override ไม่ได้อยู่จริง (CLAIMS-AUDIT Round 6)
+printf 'viewport 500 400 2\neval String(devicePixelRatio)\n' > "$WORK/run.txt"
+chk "run: viewport มีผลกับคำสั่งถัดไปในสคริปต์" "2" "$(AB run "$WORK/run.txt")"
+AB viewport 500 400 2 >/dev/null 2>&1
+chk "สั่งแยก invocation ไม่มีผล (เคสที่ทำให้ข้างบนมีความหมาย)" "1" "$(AB eval 'String(devicePixelRatio)')"
+
+echo "=== lens: หน้าที่ผิดต้อง FAIL หน้าที่ถูกต้องต้อง PASS ==="
+cat > "$WORK/bad.html" <<'HTML'
+<!doctype html><meta charset="utf-8"><title>bad</title>
+<style>body{margin:0}a.t{display:inline-block;width:10px;height:10px}</style>
+<div style="width:2000px">wide</div><a class="t" href="#">x</a>
+HTML
+cat > "$WORK/good.html" <<'HTML'
+<!doctype html><meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1"><title>good</title>
+<style>body{margin:0;font:16px sans-serif}a{display:inline-block;min-width:44px;min-height:44px}</style>
+<p>fine</p><a href="#">link</a>
+HTML
+to_file(){ printf 'file:///%s' "$(cygpath -m "$1" 2>/dev/null || echo "$1")"; }
+AB nav "$(to_file "$WORK/bad.html")" 2 >/dev/null
+chk "lens layout จับหน้าล้นแนวนอน"       '"kind": "overflow-x"'       "$(AB lens layout)"
+AB nav "$(to_file "$WORK/good.html")" 2 >/dev/null
+chk "lens layout บนหน้าที่ถูกต้อง = PASS" '"verdict": "PASS"'         "$(AB lens layout)"
+
+echo "=== UNVERIFIED ไม่ใช่ PASS (golden rule #6) ==="
+# ★ claim ที่อันตรายที่สุดของทั้งสกิล: ถ้าอันนี้ regress รายงานจะบอกว่า "ไม่มี error ฝั่ง network"
+#   ทั้งที่ไม่เคยเฝ้าเลย — และไม่มีอะไรฟ้อง เพราะผลออกมาเป็นสีเขียว
+chk "lens netlog ที่ไม่ได้ netlog on = UNVERIFIED" '"verdict": "UNVERIFIED"' "$(AB lens netlog)"
+chk "steady นอกโหมด run รายงานสิ่งที่ตั้งไม่ได้"    '"skipped": ["timezone' "$(AB steady --tz=Asia/Bangkok)"
+
 echo "=== about:blank เป็นเรื่องปกติ ไม่ใช่ paint พัง ==="
 chk "nav about:blank -> url == about:blank" "about:blank" "$(AB nav about:blank 1)"
 


### PR DESCRIPTION
Closes #41
Closes #40

## 1. บทเรียน 7 ข้อที่ไม่เคยเข้า repo (commit แยกไว้ให้ drop ง่าย)

`gotchas.md` §11–§17 กับหมายเหตุ path Windows ของ `shot`/`pdf` **เขียนไว้ตั้งแต่ 2026-08-10 แต่ค้างอยู่ในเครื่อง ไม่เคย commit**

เรื่องนี้ไม่ใช่แค่ระเบียบ — **v1.6.0 ที่เพิ่ง merge ไปอ้าง §14/§15/§16/§17** คนที่ clone ไปตามลิงก์จะเจอความว่าง · commit แรกของ PR นี้จึงเป็นเนื้อหาเดิมทั้งดุ้น ไม่แก้ถ้อยคำสักคำ เพื่อให้ drop ออกได้ถ้าไม่ต้องการ

## 2. เอกสารที่ "สอนผิด" ไม่ใช่แค่ "ไม่ครบ"

| จุด | เดิม | ของจริง |
|---|---|---|
| README ตารางงาน | `open` · `wait --load networkidle` · `errors` · `diff screenshot --baseline` | คำสั่งยุค daemon ที่ `cdp.py` ไม่มีสักตัว |
| README golden rule | "`click` does not auto-scroll, so call `scrollintoview` first" | `click` ทำ `scrollIntoView` ให้ในตัวแล้ว |
| README troubleshooting | ให้ล้าง "stale session file" ตอนเจอ `os error 10060` | ไม่มี daemon ไม่มีไฟล์นั้นแล้ว |
| ARCHITECTURE §3 | 4 ชั้น + `open`/`errors`/`diff screenshot` | 7 ชั้น + คำสั่งจริง |

เอกสารที่บอกวิธีใช้เครื่องมือผิดแย่กว่าไม่มีเอกสาร เพราะคนใหม่จะลองแล้วเจอ error ที่ไม่มีคำอธิบาย

## 3. `commands.md` มีคำสั่งใหม่แล้ว

หัวข้อ `run` (+ เหตุผลที่ไม่ใช่ daemon + กับดัก quote ของ `--body=`) และตาราง `lens`/`steady`/`netlog`/`stub` ที่ระบุว่าตัวไหนต้องอยู่ในโหมด `run`

## 4. self-test ครอบ claim ใหม่แล้ว — และตัดสินใจเรื่องการแบ่งเทส

เพิ่ม 6 เคส · **36 passed, 0 failed** (Chrome 151)

ที่สำคัญที่สุดคือเคสนี้:

```
PASS  lens netlog ที่ไม่ได้ netlog on = UNVERIFIED
```

ถ้า claim นี้ regress รายงาน QA จะเขียนว่า "ไม่มี error ฝั่ง network" ทั้งที่ไม่เคยเฝ้าเลย — **และผลจะออกมาเป็นสีเขียว ไม่มีอะไรฟ้อง**

**การแบ่งเทสระหว่างสองรีโป (บันทึกใน CLAIMS-AUDIT):** เทสลึกของ `cdp.py` อยู่ที่ `tests/test-cdp.sh` ของ `Teibto/teibto-dev-standards` ที่เดียว — ไม่ mirror มาที่นี่ เพราะจะกลายเป็นสองแหล่งที่ drift จากกัน · repo นี้เก็บเฉพาะ claim-check ของสิ่งที่ **สกิลนี้** สัญญาเอง

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LF8AvckTdLMxDx4K3hzKEK