### PR TITLE
Prepare Browser QA v2.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ## [Unreleased]
 
+## [2.0.0] - 2026-08-21
+
+**Canonical team-owned Browser QA with a direct, bounded CDP runner and one local UI.**
+
 ### Changed
 
 - ย้าย canonical ownership จากบัญชีส่วนตัวมา `Teibto/teibto-browser-qa` และเปลี่ยน skill/bundle


### PR DESCRIPTION
## Summary
- cut the first major release under the canonical Teibto ownership
- document the rename, CI gate, direct bounded CDP runner, and integrated local UI

## Verification
- skill validator passed
- 14 unit/integration tests passed
- skill bundle built with 28 entries
- v2.0.0 release notes dry-run passed
- git diff --check passed

Part of #46