### PR TITLE
feat(runner): reduce browser QA step latency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,28 @@
 
 ## [Unreleased]
 
+## [2.1.0] - 2026-08-22
+
+### Added
+
+- **Per-phase runner telemetry** — JSONL แยก startup/action/wait/assert/capture/console/total พร้อม
+  authoritative driver duration/attempts และ partial phases เมื่อ fail (#52)
+- **Async/live performance coverage** — fixture normalize input 150 ms และ defer trusted click
+  300 ms เพื่อพิสูจน์ว่า fast input ยังรอ observable outcome; protocol compatibility และ failure
+  evidence มี unit gates (#52)
+
+### Changed
+
+- Runner ต้องใช้ canonical CDP JSONL protocol v2+, ขอ `--input-settle=none`, verify ready policy และ
+  ใช้ event-bound navigation; standalone/ad-hoc driver behavior ไม่เปลี่ยน (#52)
+
+### Fixed
+
+- `networkidle` หลัง action ไม่ผ่านจาก `readyState` ของ document เก่า; runner ผูก document identity
+  ก่อน action และงาน AJAX ใช้ explicit selector/function outcome wait (#52)
+- Capture default ตรงกับ spec: `doc:true` ถ่าย step ที่ผ่าน, `doc:false` ถ่ายเฉพาะ failure และ
+  `capture` ระดับ step override ได้ (#52)
+
 ## [2.0.0] - 2026-08-21
 
 **Canonical team-owned Browser QA with a direct, bounded CDP runner and one local UI.**

--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@ Golden rule: a command that exits 0 only means it was *sent* — always assert t
 - **Documents that ship.** User guides and bug reports export to PDF with a cover, table of contents, page numbers, and highlighted screenshots.
 - **Evidence per step.** Capture screenshots and structured results that can be reviewed without a daemon, dashboard, or video dependency.
 - **One process per batch run.** `flow-runner.py` validates the flow, pins one target, and keeps one
-  bounded `cdp.py session --jsonl` process/WebSocket for every step.
+  bounded CDP JSONL v2 process/WebSocket for every step; event-bound navigation prevents old-page
+  readiness races and phase timings show driver cost separately from application waits.
 - **Fits a team.** A lifecycle playbook, a release gate, and a RACI table live in [`docs/TEAM-PROCESS.md`](docs/TEAM-PROCESS.md).
 
 ## Gotchas it protects against
@@ -138,7 +139,9 @@ $env:TEIBTO_CDP_SCRIPT = 'D:\path\to\teibto-dev-standards\scripts\cdp.py'
 
 The runner writes `run-log.jsonl`, `qa-report.md`, and `shots/`. Secrets travel over stdin and are
 redacted from events/reports. It stops on command, wait, assertion, screenshot, console, or transport
-failure; an unasserted state-changing action is `UNVERIFIED`, never `PASS`.
+failure; an unasserted state-changing action is `UNVERIFIED`, never `PASS`. It requires canonical
+`cdp.py` JSONL protocol v2+ and fails with `DRIVER_INCOMPATIBLE` instead of silently running a slow/
+unsafe policy on an older driver.
 
 Optional local UI: set `TGT_ID` (or enter it in the page), then run `node app/server.js` and open
 `http://127.0.0.1:4173`. The server binds locally, uses the same runner, and has no browser daemon,

--- a/SKILL.md
+++ b/SKILL.md
@@ -120,8 +120,10 @@ QA ผิด = รายงานผิด แต่ config ผิด = ระ�
 
 **Store test cases as repeatable files** (regression/repro) → write them as flow YAML and run them
 with `scripts/flow-runner.py`: `references/flow-spec.md`. Runner validate schema ก่อน, บังคับ
-`TGT_ID`, เปิด `cdp.py session --jsonl` เพียง process/WebSocket เดียวต่อ run และ fail-fast โดยไม่มี
-JS-click fallback. งานสำรวจแบบ ad-hoc ยังใช้คำสั่ง `AB` ตามปกติได้
+`TGT_ID`, ต้องใช้ `cdp.py` protocol v2+, เปิด bounded `session --jsonl --input-settle=none` เพียง
+process/WebSocket เดียวต่อ run, รอ navigation ด้วย main-frame event และย้ายการรอ application
+ไปไว้ที่ bounded outcome wait + assertion. ทุก step คืน phase timing แยก action/wait/assert/capture;
+fail-fast โดยไม่มี JS-click fallback. งานสำรวจแบบ ad-hoc ยังใช้คำสั่ง `AB` และ fixed settle ตามปกติได้
 
 Suggested artifact layout:
 ```

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -53,12 +53,14 @@ flowchart LR
     yaml["flow YAML"] --> schema["flow.schema.json<br/>fail closed"]
     ui["local UI<br/>127.0.0.1"] --> runner
     schema --> runner["flow-runner.py<br/>events + report + shots"]
-    runner -->|"stdin/stdout JSONL<br/>one child per run"| session["cdp.py session<br/>bounded + pinned target"]
+    runner -->|"JSONL v2 · one child per run<br/>event nav + phase timing"| session["cdp.py session<br/>bounded + pinned target<br/>input-settle=none"]
     session -->|"one WebSocket"| chrome["Chrome target"]
     runner --> artifacts["run-log.jsonl<br/>qa-report.md<br/>shots/"]
 ```
 
-Secrets enter the runner through stdin, not argv. An action, wait, screenshot, console check, or
+Secrets enter the runner through stdin, not argv. Fixed input sleeps are removed only in this
+bounded runner contract; observable application latency is paid in explicit waits and reported
+separately from action/assert/capture driver time. An action, wait, screenshot, console check, or
 transport failure stops the scenario. Unasserted state-changing actions produce `UNVERIFIED`.
 
 ---

--- a/docs/CLAIMS-AUDIT.md
+++ b/docs/CLAIMS-AUDIT.md
@@ -10,6 +10,9 @@ claim ที่ผูกกับ **Chrome/หน้าเว็บ** ยัง�
 **Round 6 (2026-08-16):** วัดใหม่บน **Chrome 151** พร้อมคำสั่งชุด `run`/`lens`/`steady`/`netlog`/`stub`
 (`Teibto/teibto-dev-standards` #188/#190/#192 · `tests/test-cdp.sh` 88 เคสกับ Chrome จริง)
 
+**Round 7 (2026-08-22):** canonical CDP protocol v2 + runner latency/async-wait evidence อยู่ท้ายไฟล์;
+driver real-Chrome suite 123 เคส และ Browser QA live flow วัด phase ก่อน–หลังแบบ isolated (#259/#52).
+
 | claim | สถานะ | Risk | Smoke |
 |---|---|---|---|
 | **"`viewport` ข้าม invocation ไม่มีผล" (Round 5) — หยาบเกินไป** | **แก้แล้ว** วัดจริงพบว่ามันแยกร่าง: **ขนาดหน้าต่างค้าง** ข้าม invocation (Chrome resize หน้าต่างจริง) ส่วน **dsf/mobile ไม่ค้าง** · เป็นเหตุผลที่เทส T11e กับ T18e ในชุดเดียวกันดูขัดกันเองแต่ผ่านทั้งคู่มาตลอด | MED (version-pinned: Chrome 151) | T19a/T19b |
@@ -205,3 +208,40 @@ while keeping its keys.
 hardening that "rejects unsafe startup arguments" — the latter is **not** re-verified here against the
 black-window launch flags (`--disable-gpu`, `--disable-features=CalculateNativeWinOcclusion`) because
 that launcher lives in another repo. Flag for manual check before relying on those flags on 0.3x.
+
+---
+
+## Round 7 — bounded CDP protocol v2 latency (2026-08-22)
+
+Claims below are version-pinned to the real Chrome installed on the Windows test host and the
+canonical `cdp.py` branch for teibto-dev-standards#259. They are measurements, not universal
+machine-specific budgets.
+
+| Claim | Evidence | Adjudication |
+|---|---|---|
+| Event-bound `nav` prevents old-document readiness and keeps dialog/redirect behavior bounded | canonical real-Chrome `tests/test-cdp.sh` T16c–T16j | **verified**: server redirect, delayed 300 ms response, beforeunload dismiss/accept and final-page DOM all covered |
+| Collector captures load-time console errors without accumulating across pages | canonical T15 + T16d | **verified**: preload catches a script error on the redirect final document; per-page reset tests remain green |
+| `--input-settle=none` is scoped and explicit waits retain async correctness | canonical T19u/v + this repo `tests/test-flow-runner-live.sh` | **verified**: direct input ≥4× faster than fixed by relative gate; `pick`/`lens` retain settle; live fixture normalizes input after 150 ms and updates trusted click outcome after 300 ms |
+| Runner step-flow median is materially faster and stable under async delay | five isolated baseline runs + 20 final fast-policy runs | **measured**: 4,373.865 → 622.523 ms median summed step time (**85.8% faster**); 20/20 PASS, zero false FAIL; median `run_done` including 181.014 ms startup = 823.390 ms |
+
+Final 20-run result (one temporary Chrome/target, a fresh bounded child session each run):
+
+```text
+{"runs":20,"failures":0,"median_ms":{"startup_ms":181.014,"open_ms":30.552,
+"fill_ms":171.488,"click_ms":396.767,"step_total_ms":622.523,"run_total_ms":823.39}}
+```
+
+Baseline came from main commits `teibto-browser-qa@3ecafee` +
+`teibto-dev-standards@6656b9c`, five isolated runs of the same three-step live runner shape. The new
+fixture deliberately adds 150/300 ms application delays, so the improvement is conservative: those
+delays now appear in the wait phase instead of being hidden by fixed driver sleeps. Reproduce the
+post-change integration run with:
+
+```powershell
+$env:TEIBTO_CDP_SCRIPT = '<teibto-dev-standards>/scripts/cdp.py'
+$env:LIVE_RUNS = '20'
+& 'C:\Program Files\Git\bin\bash.exe' tests/test-flow-runner-live.sh
+```
+
+The portable performance gate is ratio-based in canonical `tests/cdp-session-probe.py`; the absolute
+milliseconds above remain evidence only and are not used as a cross-machine CI threshold.

--- a/references/commands.md
+++ b/references/commands.md
@@ -33,7 +33,8 @@ export TGT_ID=$(AB newtab "<url>?job=<ชื่องาน>")
 
 | คำสั่ง | ใช้ทำ |
 |---|---|
-| `nav <url> [wait]` | เปิดหน้า แล้วรอ (ยังตอบ JS dialog ระหว่างรอ) · ติดตั้ง console collector ให้อัตโนมัติ |
+| `nav <url> [wait]` | เปิดหน้า แล้ว drain event ตามวินาที (default 3; ยังตอบ JS dialog) · ติดตั้ง console collector |
+| `nav <url> --until=load [--timeout=N]` | protocol v2: รอ main-frame commit/load จริงสำหรับ runner; cancel/timeout = fail loud |
 | `click <sel\|@ref>` | คลิก **จริง** ด้วย Input event · `scrollIntoView` ให้ในตัว |
 | `fill <sel\|@ref> <text>` | โฟกัสจริง → ล้าง → พิมพ์จริง → Tab |
 | `type <text>` | พิมพ์ลง element ที่โฟกัสอยู่ |
@@ -75,12 +76,15 @@ ref เป็น `backendNodeId` ซึ่ง **คงที่ตลอดอ�
 ## รอแบบฉลาด (อย่ารอ fixed ms กับหน้า async)
 
 ```bash
-AB wait "document.readyState==='complete'" 20
+AB wait "document.readyState==='complete'" 20 0.05   # arg 3 = poll interval (วินาที)
 AB wait "!!document.querySelector('#done')" 15
 AB wait "window.jQuery ? jQuery.active===0 : true" 20     # หน้า async ที่ใช้ jQuery (NetSuite)
 ```
 
 `wait` **exit 1 เมื่อหมดเวลา** → ใช้กับ `&&` / `set -e` ได้ตรง ๆ ให้ flow หยุดตรงจุดที่พังจริง
+
+หลังสั่ง navigation ห้ามใช้ `nav <url> 0` + `readyState` อย่างเดียว เพราะหน้าเก่าอาจ complete
+อยู่แล้ว; runner ใช้ `nav --until=load` ก่อน outcome wait.
 
 > ไม่มี `--load networkidle` ให้ใช้ · เขียนเงื่อนไขที่**เจาะจงกับหน้าที่กำลังทดสอบ** แทน
 > ซึ่งดีกว่าอยู่แล้ว — networkidle เดาไม่ถูกว่า "นิ่ง" ของแอปนี้แปลว่าอะไร และบนบางหน้า
@@ -239,7 +243,7 @@ AB evalf /tmp/step.js
 | `snapshot -i` + ref `@eN` | `a11y [คำค้น]` + ref `@<backendNodeId>` |
 | `find role button click --name "X"` | `a11y "X"` แล้ว `click "@<ref>"` |
 | `errors --json` / `console --json` | `console` — **collector ผูกกับหน้า ไม่ใช่ buffer สะสม** |
-| `wait --fn "<js>"` · `wait <sel>` · `wait --load networkidle` | `wait "<js>" [timeout]` |
+| `wait --fn "<js>"` · `wait <sel>` · `wait --load networkidle` | `wait "<js>" [timeout] [poll]` |
 | `screenshot <path>` · `screenshot <sel> <path>` | `shot <path>` · `shot <path> <sel>` |
 | `diff screenshot --baseline <a> -o <b>` | `diff <a> <b> [out]` |
 | `pdf <path>` | `pdf <path>` |

--- a/references/flow-spec.md
+++ b/references/flow-spec.md
@@ -15,7 +15,9 @@ $env:TEIBTO_CDP_SCRIPT = 'D:\path\to\teibto-dev-standards\scripts\cdp.py'
 
 - flow ทุกไฟล์ผ่าน `schemas/flow.schema.json` และ field ที่ไม่รู้จักทำให้หยุดทันที
 - secret ส่งผ่าน stdin (`--vars-json -`), ไม่อยู่ใน process argv/log/report
-- หนึ่ง run ใช้ target ที่ pin และ `cdp.py session --jsonl` เพียง process/WebSocket เดียว
+- หนึ่ง run ใช้ target ที่ pin และ `cdp.py` JSONL protocol v2+ เพียง process/WebSocket เดียว;
+  runner ขอ `--input-settle=none` และ verify policy จาก ready handshake แบบ fail closed
+- `open` รอ main-frame commit/load event จริง; ไม่ใช้ zero-drain + `readyState` ที่อาจอ่านหน้าเก่า
 - `click` ใช้ native input เท่านั้น; ไม่มี JS fallback เงียบ
 - action/wait/assert/screenshot/console ล้ม = หยุด scenario และ verdict `FAIL`
 - action ที่เปลี่ยน state แต่ไม่มี explicit assertion = verdict `UNVERIFIED`, ไม่ใช่ `PASS`
@@ -59,7 +61,8 @@ scenarios:
         action: open|fill|click|select|press|scrollintoview|eval|wait
         target: "<selector | @eN | {{var}} | url>"
         value: "<ค่า/ข้อความ (สำหรับ fill/select) — รองรับ {{var}}>"
-        wait: networkidle | <ms> | "<selector>"    # รอหลัง action
+        wait: networkidle | <ms> | "<selector>" | "fn:<js>"  # รอหลัง action
+        capture: true|false        # override screenshot policy ของ scenario นี้
         assert:                  # พิสูจน์ผล (ตาม gotchas: อย่าเชื่อ ✓Done)
           url_contains: "/inventory.html"
           # หรือ: { target: ".shopping_cart_badge", contains: "1" }
@@ -68,6 +71,16 @@ scenarios:
 **assert forms ที่ใช้บ่อย:** `url_contains: "..."` · `{ target: "<sel>", contains: "<text>" }`.
 ทุก step ที่เปลี่ยน application state **ต้องมี assert** — runner คืน `UNVERIFIED` ถ้าไม่มี
 (การ `fill` ตรวจ value หลังกรอกให้อัตโนมัติ แต่ action ที่ submit/เปลี่ยนข้อมูลยังต้อง assert ผลธุรกิจ).
+
+`networkidle` เป็นชื่อเดิมเพื่อ compatibility แต่ contract จริงคือ **navigation-ready** ไม่ใช่
+เครือข่ายนิ่ง: `open` ใช้ event ของ main frame; หลัง action อื่น runner ปัก document identity ก่อนทำ
+action แล้วรอ URL/time origin เปลี่ยนพร้อม `readyState=complete`, จึงไม่ผ่านจากหน้าเก่า. งาน AJAX/
+Oracle JET ให้ใช้ selector หรือ `fn:<observable outcome>` เช่น
+`fn:document.querySelector('#status').textContent==='saved'` แล้ว assert ครั้งเดียว.
+
+`run-log.jsonl` เก็บ runner wall-clock และ authoritative driver `duration_ms`/`attempts` แยก
+`action`, `wait`, `assert`, `capture`; failure มี partial phases + `failing_phase`, console check มี
+timing ของตัวเอง และ `run_done` แยก startup/total.
 
 **Traceability (สำหรับทีม):** `ticket`/`requirement` + `acceptance` ทำให้ตอบได้ว่า *test นี้ยืนยัน
 req ไหน* และ *req นี้ครอบด้วย scenario ไหน*. 1 acceptance criterion → 1 scenario (map 1:1) →
@@ -96,7 +109,8 @@ Schema จึงปฏิเสธ field เหล่านี้แทนกา
    - adversarial: scenario แยก `doc: false` — ยิง edge value ผ่าน `vars` (ไทย/emoji/boundary/
      injection payload) แล้ว assert ว่า error **surface** (ไม่ใช่ Pass เงียบ).
 3. **Run** — ขับด้วย `scripts/flow-runner.py` ผ่าน JSONL session เดียว คืน `run-log.jsonl`.
-   screenshot ทุก step เฉพาะ scenario `doc:true`; adversarial ถ่ายเฉพาะตอนเจอ bug.
+   screenshot ทุก step เฉพาะ scenario `doc:true`; adversarial `doc:false` ไม่ถ่ายตอนผ่านแต่ถ่าย
+   failure เป็นหลักฐาน. `capture:true|false` ที่ step override ทั้งสองกรณีได้.
 4. **Report** — `qa-report.md` (ตาราง Phase 3) + ป้อน bug เข้า `assets/bug-report-template.html`,
    guide จาก scenario `doc:true` เข้า `assets/guide-template.html`.
 

--- a/references/gotchas.md
+++ b/references/gotchas.md
@@ -63,9 +63,10 @@
 - **collector ตายพร้อมหน้า** — navigate แล้ว log เริ่มใหม่ · **นี่คือพฤติกรรมที่ต้องการ**:
   buffer สะสมข้ามหน้า (แบบที่ `agent-browser errors` ทำ) ทำให้ error ของหน้าก่อนถูกนับเป็นของ
   หน้านี้ ซึ่งเป็น false PASS ที่จับยากมาก
-- **error ที่เกิด "ก่อน" collector ถูกติดตั้ง จับไม่ได้** — script ที่ throw ตอน parse ของหน้า
-  อยู่ก่อนเราเสมอ · ต้องจับ error ตอน load จริง ๆ ให้เปิดหน้าเปล่าก่อน inject แล้วค่อย
-  `location.href = <target>`
+- `cdp.py` protocol v2 register collector ด้วย `Page.addScriptToEvaluateOnNewDocument` ก่อน `nav`
+  ใน connection เดียวกัน จึงจับ load-time error ได้; post-nav eval ใช้ verify/fallback
+- **หน้าที่เปิด/เปลี่ยนไปก่อน connection ปัจจุบัน register collector ยังจับย้อนหลังไม่ได้** — เช่น
+  คนเปิดแท็บไว้ก่อน หรือ one-shot `nav` จบแล้วแอป navigate เองภายหลัง · `console` จะ error ไม่ใช่ `[]`
 - เก็บสูงสุด **200 รายการต่อหน้า** — หน้าที่ spam error จะถูกตัดท้าย
 
 ---
@@ -225,6 +226,10 @@ Get-CimInstance Win32_Process -Filter "Name='chrome.exe'" |
 AB nav "<url>" 3                                    # drain 3 วิ
 AB wait "document.readyState==='complete'" 15       # เงื่อนไขอยู่ที่ wait เท่านั้น
 ```
+
+Runner/protocol v2 ใช้ `AB nav "<url>" --until=load --timeout=30` เพื่อรอ main-frame commit/load
+จริง. **ห้าม optimize ด้วย `nav <url> 0` แล้ว wait `readyState` อย่างเดียว**: document เก่าอาจเป็น
+`complete` อยู่แล้ว ทำให้ wait ผ่านก่อน navigation commit และ assertion อ่านหน้าเก่าเป็น false PASS.
 
 **ผลข้างเคียงที่แพงกว่าตัว error:** `nav` เป็นคำสั่งที่ติดตั้ง console collector ให้ · `nav` ล้ม =
 ไม่มี collector → `AB console` คำสั่งถัดไปตอบว่า "collector ยังไม่ถูกติดตั้ง" ซึ่ง**ถูก** แต่ถ้าอ่านผ่าน ๆ

--- a/references/reliability-policy.md
+++ b/references/reliability-policy.md
@@ -33,6 +33,11 @@ process. การ retry ทั้ง scenario ต้องเป็นการ
   retry: แก้ด้วย `wait "<เงื่อนไขผลลัพธ์>"` ก่อน assert (gotchas.md §2)
   แล้ว assert **ครั้งเดียว**. อย่าเปลี่ยน "รอให้ถูก" เป็น "ยิงซ้ำจนบังเอิญผ่าน".
 
+Runner protocol v2 ตัด fixed input settle เฉพาะ `click`/`fill`/`press` ที่ runner ส่งตรง. `fill`
+จึง poll ค่า exact แบบ bounded หลัง action; click/press ต้องมี `wait` ของ observable outcome ก่อน
+assert. เวลาของแอปอยู่ใน wait phase ไม่ใช่ถูกลบออก. `networkidle` ใช้เฉพาะ navigation-ready;
+AJAX/component state ใช้ selector หรือ `fn:<js>` ที่เจาะจง.
+
 เส้นแบ่ง: **ต่อ browser ไม่ติด = retry ได้. แอปให้ผลผิด = FAIL.** ถ้าแยกไม่ออก ให้ถือเป็น FAIL.
 
 ---

--- a/scripts/flow-runner.py
+++ b/scripts/flow-runner.py
@@ -41,6 +41,9 @@ PLACEHOLDER = re.compile(r"\{\{\s*([A-Za-z_][A-Za-z0-9_]*)\s*\}\}")
 # change application state but have no trustworthy implicit success signal.
 MUTATING_ACTIONS = {"click", "select", "press", "eval"}
 MAX_EVENT_TEXT = 2_000
+SESSION_PROTOCOL = "teibto-cdp-jsonl"
+MIN_SESSION_VERSION = 2
+INPUT_SETTLE_POLICY = "none"
 
 
 class RunnerError(RuntimeError):
@@ -173,6 +176,7 @@ class CDPSession:
             f"--target-id={target_id}",
             "--idle-timeout=120",
             "--max-lifetime=1800",
+            f"--input-settle={INPUT_SETTLE_POLICY}",
         ]
         env = os.environ.copy()
         if port:
@@ -198,8 +202,26 @@ class CDPSession:
         if ready.get("type") != "ready" or not ready.get("ok"):
             error = ready.get("error") or {}
             self.close(force=True)
-            raise RunnerError(error.get("code", "CDP_NOT_READY"),
-                              error.get("message", "CDP session ไม่พร้อม"), detail=ready)
+            message = error.get("message", "CDP session ไม่พร้อม")
+            if error.get("code") == "INVALID_ARGS" and "input-settle" in message:
+                raise RunnerError(
+                    "DRIVER_INCOMPATIBLE",
+                    f"cdp.py เก่าเกินไป: runner ต้องใช้ {SESSION_PROTOCOL} v{MIN_SESSION_VERSION}+ "
+                    f"ที่รองรับ --input-settle={INPUT_SETTLE_POLICY}",
+                    detail=ready,
+                )
+            raise RunnerError(error.get("code", "CDP_NOT_READY"), message, detail=ready)
+        version = ready.get("version")
+        if (ready.get("protocol") != SESSION_PROTOCOL or not isinstance(version, int)
+                or version < MIN_SESSION_VERSION
+                or ready.get("input_settle") != INPUT_SETTLE_POLICY):
+            self.close(force=True)
+            raise RunnerError(
+                "DRIVER_INCOMPATIBLE",
+                f"runner ต้องใช้ {SESSION_PROTOCOL} v{MIN_SESSION_VERSION}+ "
+                f"และ input_settle={INPUT_SETTLE_POLICY}",
+                detail=ready,
+            )
         if ready.get("target_id") != target_id:
             self.close(force=True)
             raise RunnerError("TARGET_MISMATCH", "CDP ต่อผิด target", detail=ready)
@@ -279,6 +301,81 @@ class CDPSession:
             self.process.wait(timeout=3)
 
 
+class StepTimings:
+    """Runner wall time + authoritative driver timings, split by observable phase."""
+
+    def __init__(self) -> None:
+        self.started = time.perf_counter()
+        self.phases: dict[str, dict[str, float | int]] = {}
+        self.failing_phase: str | None = None
+
+    def _phase(self, name: str) -> dict[str, float | int]:
+        return self.phases.setdefault(name, {
+            "wall_ms": 0.0, "driver_ms": 0.0, "commands": 0, "attempts": 0,
+        })
+
+    def command(self, session: CDPSession, phase: str, command: str,
+                args: list[Any] | None = None) -> dict[str, Any]:
+        bucket = self._phase(phase)
+        started = time.perf_counter()
+        try:
+            result = session.command(command, args)
+            self._record_driver(bucket, result)
+            return result
+        except RunnerError as exc:
+            if isinstance(exc.detail, dict):
+                self._record_driver(bucket, exc.detail)
+            if self.failing_phase is None:
+                self.failing_phase = phase
+            raise
+        finally:
+            bucket["wall_ms"] = float(bucket["wall_ms"]) + (
+                time.perf_counter() - started
+            ) * 1000
+
+    def sleep(self, phase: str, seconds: float) -> None:
+        bucket = self._phase(phase)
+        started = time.perf_counter()
+        try:
+            time.sleep(seconds)
+        except BaseException:
+            if self.failing_phase is None:
+                self.failing_phase = phase
+            raise
+        finally:
+            bucket["wall_ms"] = float(bucket["wall_ms"]) + (
+                time.perf_counter() - started
+            ) * 1000
+
+    def fail(self, phase: str) -> None:
+        if self.failing_phase is None:
+            self.failing_phase = phase
+
+    @staticmethod
+    def _record_driver(bucket: dict[str, float | int], result: dict[str, Any]) -> None:
+        if isinstance(result.get("duration_ms"), (int, float)):
+            bucket["driver_ms"] = float(bucket["driver_ms"]) + float(result["duration_ms"])
+            bucket["commands"] = int(bucket["commands"]) + 1
+            bucket["attempts"] = int(bucket["attempts"]) + int(result.get("attempts") or 0)
+
+    def payload(self) -> dict[str, Any]:
+        phases = {
+            name: {
+                "wall_ms": round(float(values["wall_ms"]), 3),
+                "driver_ms": round(float(values["driver_ms"]), 3),
+                "commands": int(values["commands"]),
+                "attempts": int(values["attempts"]),
+            }
+            for name, values in self.phases.items()
+        }
+        payload: dict[str, Any] = {
+            "total_ms": round((time.perf_counter() - self.started) * 1000, 3),
+            "phases": phases,
+        }
+        if self.failing_phase:
+            payload["failing_phase"] = self.failing_phase
+        return payload
+
 def js_selector(selector: str) -> str:
     return json.dumps(selector, ensure_ascii=False)
 
@@ -289,61 +386,89 @@ def selector_wait(selector: str) -> str:
             "return r.width>0&&r.height>0&&s.visibility!=='hidden';})()") % js_selector(selector)
 
 
-def perform_action(session: CDPSession, step: dict[str, Any], variables: dict[str, Any]) -> None:
+def perform_action(session: CDPSession, step: dict[str, Any], variables: dict[str, Any],
+                   timings: StepTimings) -> dict[str, Any]:
     action = step["action"]
     target = substitute(step.get("target", ""), variables)
     value = substitute(step.get("value", ""), variables)
+    context: dict[str, Any] = {}
+    if step.get("wait") == "networkidle" and action != "open":
+        context["document_before"] = timings.command(
+            session,
+            "action",
+            "eval",
+            ["JSON.stringify({href:location.href,timeOrigin:performance.timeOrigin})"],
+        ).get("data")
     if action == "open":
-        session.command("nav", [target])
+        timings.command(session, "action", "nav", [target, "--until=load", "--timeout=30"])
     elif action == "fill":
-        session.command("fill", [target, value])
-        result = session.command("get", ["value", target]).get("data")
-        if str(result) != str(value):
-            raise RunnerError("FILL_NOT_APPLIED", f"ค่าใน {target} ไม่ตรงหลัง fill")
+        timings.command(session, "action", "fill", [target, value])
+        deadline = time.monotonic() + 5
+        while True:
+            actual = timings.command(session, "wait", "get", ["value", target]).get("data")
+            if str(actual) == str(value):
+                break
+            if time.monotonic() >= deadline:
+                timings.fail("wait")
+                raise RunnerError("FILL_NOT_APPLIED", f"ค่าใน {target} ไม่ตรงหลัง fill")
+            timings.sleep("wait", min(0.05, max(0, deadline - time.monotonic())))
     elif action == "click":
-        session.command("click", [target])
+        timings.command(session, "action", "click", [target])
     elif action == "select":
-        session.command("pick", [target, value])
+        timings.command(session, "action", "pick", [target, value])
     elif action == "press":
-        session.command("key", [target])
+        timings.command(session, "action", "key", [target])
     elif action == "scrollintoview":
         expression = ("(function(){var e=document.querySelector(%s);if(!e)return false;"
                       "e.scrollIntoView({block:'center'});return true;})()") % js_selector(target)
-        if session.command("eval", [expression]).get("data") is not True:
+        if timings.command(session, "action", "eval", [expression]).get("data") is not True:
+            timings.fail("action")
             raise RunnerError("ELEMENT_MISSING", f"ไม่พบ element: {target}")
     elif action == "eval":
-        session.command("eval", [target])
+        timings.command(session, "action", "eval", [target])
     elif action == "wait":
         if target:
             expression = target[3:] if target.startswith("fn:") else selector_wait(target)
-            session.command("wait", [expression, "20"])
+            timings.command(session, "wait", "wait", [expression, "20", "0.05"])
     else:  # schema should make this unreachable
+        timings.fail("action")
         raise RunnerError("INVALID_ACTION", f"action ไม่รองรับ: {action}")
+    return context
 
 
-def perform_wait(session: CDPSession, wait: Any, variables: dict[str, Any]) -> None:
+def perform_wait(session: CDPSession, wait: Any, variables: dict[str, Any],
+                 context: dict[str, Any], timings: StepTimings) -> None:
     if wait is None:
         return
     if wait == "networkidle":
-        # CDP transport does not claim true network-idle; this is an explicit document-ready wait.
-        session.command("wait", ["document.readyState === 'complete'", "30"])
+        # ชื่อนี้คงไว้เพื่อ compatibility แต่ contract คือ document navigation-ready ไม่ใช่ network idle.
+        before = context.get("document_before")
+        if isinstance(before, dict):
+            expression = (
+                "document.readyState==='complete'&&"
+                "(location.href!==%s||performance.timeOrigin!==%s)"
+            ) % (json.dumps(str(before.get("href", "")), ensure_ascii=False),
+                 json.dumps(before.get("timeOrigin")))
+        else:
+            expression = "document.readyState === 'complete'"
+        timings.command(session, "wait", "wait", [expression, "30", "0.05"])
     elif isinstance(wait, int):
-        time.sleep(wait / 1000)
+        timings.sleep("wait", wait / 1000)
     elif isinstance(wait, str):
         rendered = substitute(wait, variables)
         expression = rendered[3:] if rendered.startswith("fn:") else selector_wait(rendered)
-        session.command("wait", [expression, "20"])
+        timings.command(session, "wait", "wait", [expression, "20", "0.05"])
 
 
 def perform_assert(session: CDPSession, assertion: dict[str, Any],
-                   variables: dict[str, Any]) -> tuple[bool, str]:
+                   variables: dict[str, Any], timings: StepTimings) -> tuple[bool, str]:
     if "url_contains" in assertion:
         wanted = substitute(assertion["url_contains"], variables)
-        actual = str(session.command("url").get("data") or "")
+        actual = str(timings.command(session, "assert", "url").get("data") or "")
         return wanted in actual, f'URL contains "{wanted}" (actual: {actual[:300]})'
     target = substitute(assertion["target"], variables)
     wanted = substitute(assertion["contains"], variables)
-    actual = str(session.command("get", ["text", target]).get("data") or "")
+    actual = str(timings.command(session, "assert", "get", ["text", target]).get("data") or "")
     return wanted in actual, f'{target} contains "{wanted}" (actual: {actual[:300]})'
 
 
@@ -374,6 +499,7 @@ def flow_meta(flow: dict[str, Any], path: Path, *, full: bool = False) -> dict[s
 
 def run_flow(flow: dict[str, Any], path: Path, output_dir: Path, variables: dict[str, Any],
              cdp_script: Path, target_id: str, port: str | None, sink: EventSink) -> int:
+    run_started = time.perf_counter()
     output_dir.mkdir(parents=True, exist_ok=True)
     shots = output_dir / "shots"
     shots.mkdir()
@@ -385,12 +511,22 @@ def run_flow(flow: dict[str, Any], path: Path, output_dir: Path, variables: dict
     passed = failures = unverified = 0
     session: CDPSession | None = None
     sink.emit({"type": "run_start", "story": flow["story"], "title": flow["title"],
+               "driver_policy": {"protocol": SESSION_PROTOCOL,
+                                 "min_version": MIN_SESSION_VERSION,
+                                 "input_settle": INPUT_SETTLE_POLICY,
+                                 "navigation": "event-bound-load"},
                "scenarios": [{"id": item["id"], "steps": len(item["steps"])}
                              for item in flow["scenarios"]]})
+    startup_started = time.perf_counter()
+    startup_ms: float | None = None
     try:
         session = CDPSession(cdp_script, target_id, port=port)
+        startup_ms = round((time.perf_counter() - startup_started) * 1000, 3)
         sink.emit({"type": "session_ready", "target_id": target_id,
-                   "protocol": session.ready.get("protocol"), "port": session.ready.get("port")})
+                   "protocol": session.ready.get("protocol"),
+                   "version": session.ready.get("version"),
+                   "input_settle": session.ready.get("input_settle"),
+                   "port": session.ready.get("port"), "duration_ms": startup_ms})
         global_index = 0
         for scenario in flow["scenarios"]:
             scenario_failed = False
@@ -401,15 +537,16 @@ def run_flow(flow: dict[str, Any], path: Path, output_dir: Path, variables: dict
                 intent = raw_step.get("intent", raw_step["action"])
                 sink.emit({"type": "step", "scenario": scenario["id"], "index": index,
                            "global_index": global_index, "intent": intent, "status": "running"})
-                started = time.perf_counter()
+                timings = StepTimings()
                 try:
-                    perform_action(session, raw_step, variables)
-                    perform_wait(session, raw_step.get("wait"), variables)
+                    context = perform_action(session, raw_step, variables, timings)
+                    perform_wait(session, raw_step.get("wait"), variables, context, timings)
                     assertion = raw_step.get("assert")
                     status, detail = "done", ""
                     if assertion:
-                        ok, detail = perform_assert(session, assertion, variables)
+                        ok, detail = perform_assert(session, assertion, variables, timings)
                         if not ok:
+                            timings.fail("assert")
                             raise RunnerError("ASSERTION_FAILED", detail)
                         passed += 1
                         status = "pass"
@@ -417,31 +554,57 @@ def run_flow(flow: dict[str, Any], path: Path, output_dir: Path, variables: dict
                         unverified += 1
                         status, detail = "unverified", "state-changing step has no explicit assertion"
                     shot = None
-                    if raw_step.get("capture", True):
+                    capture_success = (raw_step["capture"] if "capture" in raw_step
+                                       else bool(scenario.get("doc", False)))
+                    if capture_success:
                         shot_path = (shots / f"{scenario['id']}-{index:02d}.png").resolve()
-                        session.command("shot", [str(shot_path)])
+                        timings.command(session, "capture", "shot", [str(shot_path)])
                         shot = str(shot_path)
                     marker = "✅" if status == "pass" else ("⚠️" if status == "unverified" else "▸")
                     report.append(f"- {marker} {intent}" + (f" — {detail}" if detail else ""))
+                    timing_payload = timings.payload()
                     sink.emit({"type": "step_done", "scenario": scenario["id"], "index": index,
                                "global_index": global_index, "intent": intent, "status": status,
                                "detail": detail, "shot": shot,
-                               "duration_ms": round((time.perf_counter() - started) * 1000, 3)})
+                               "duration_ms": timing_payload["total_ms"],
+                               "timings": timing_payload})
                 except RunnerError as exc:
                     failures += 1
                     scenario_failed = True
+                    shot = None
+                    evidence_error = None
+                    if raw_step.get("capture", True):
+                        try:
+                            shot_path = (shots / f"{scenario['id']}-{index:02d}-failure.png").resolve()
+                            timings.command(session, "capture", "shot", [str(shot_path)])
+                            shot = str(shot_path)
+                        except RunnerError as capture_exc:
+                            evidence_error = {"code": capture_exc.code, "message": str(capture_exc)}
                     report.append(f"- ❌ {intent} — {exc.code}: {exc}")
+                    timing_payload = timings.payload()
                     sink.emit({"type": "step_done", "scenario": scenario["id"], "index": index,
                                "global_index": global_index, "intent": intent, "status": "fail",
                                "error": {"code": exc.code, "message": str(exc)},
-                               "duration_ms": round((time.perf_counter() - started) * 1000, 3)})
+                               "shot": shot,
+                               **({"evidence_error": evidence_error} if evidence_error else {}),
+                               "duration_ms": timing_payload["total_ms"],
+                               "timings": timing_payload})
                     break
             if not scenario_failed:
+                console_started = time.perf_counter()
+                console_result: dict[str, Any] | None = None
                 try:
-                    console = session.command("console").get("data")
+                    console_result = session.command("console")
+                    console = console_result.get("data")
                     messages = console if isinstance(console, list) else ([] if console in (None, [], "[]") else console)
                     empty = not messages
+                    console_timing = {
+                        "wall_ms": round((time.perf_counter() - console_started) * 1000, 3),
+                        "driver_ms": console_result.get("duration_ms"),
+                        "attempts": console_result.get("attempts"),
+                    }
                     sink.emit({"type": "errors", "scenario": scenario["id"], "empty": empty,
+                               "timing": console_timing,
                                **({"msgs": messages} if not empty else {})})
                     if not empty:
                         failures += 1
@@ -453,7 +616,13 @@ def run_flow(flow: dict[str, Any], path: Path, output_dir: Path, variables: dict
                     failures += 1
                     scenario_failed = True
                     report.append(f"- ❌ Console verification unavailable — {exc.code}: {exc}")
+                    detail = exc.detail if isinstance(exc.detail, dict) else {}
                     sink.emit({"type": "errors", "scenario": scenario["id"], "empty": False,
+                               "timing": {
+                                   "wall_ms": round((time.perf_counter() - console_started) * 1000, 3),
+                                   "driver_ms": detail.get("duration_ms"),
+                                   "attempts": detail.get("attempts"),
+                               },
                                "error": {"code": exc.code, "message": str(exc)}})
             sink.emit({"type": "scenario_done", "id": scenario["id"],
                        "status": "fail" if scenario_failed else "done"})
@@ -476,6 +645,8 @@ def run_flow(flow: dict[str, Any], path: Path, output_dir: Path, variables: dict
     report_path.write_text(str(safe_report), encoding="utf-8")
     sink.emit({"type": "run_done", "passed": passed, "total": assertions,
                "failures": failures, "unverified": unverified, "verdict": verdict,
+               "duration_ms": round((time.perf_counter() - run_started) * 1000, 3),
+               "startup_ms": startup_ms,
                "report": str(report_path.resolve())})
     return 0 if verdict == "PASS" else 1
 

--- a/tests/fixtures/fake_cdp.py
+++ b/tests/fixtures/fake_cdp.py
@@ -6,12 +6,21 @@ import pathlib
 import sys
 
 target = next((arg.split("=", 1)[1] for arg in sys.argv if arg.startswith("--target-id=")), "")
+input_settle = next((arg.split("=", 1)[1] for arg in sys.argv
+                     if arg.startswith("--input-settle=")), "fixed")
 counter = os.environ.get("FAKE_CDP_COUNTER")
 if counter:
     with open(counter, "a", encoding="utf-8") as handle:
         handle.write("start\n")
+if os.environ.get("FAKE_CDP_REJECT_INPUT_SETTLE") and input_settle != "fixed":
+    print(json.dumps({"type": "error", "ok": False,
+                      "error": {"code": "INVALID_ARGS",
+                                "message": f"session: flag ไม่รู้จัก: --input-settle={input_settle}",
+                                "transient": False}}), flush=True)
+    raise SystemExit(2)
 print(json.dumps({"type": "ready", "ok": True, "protocol": "teibto-cdp-jsonl",
-                  "version": 1, "target_id": target, "port": 9222}), flush=True)
+                  "version": int(os.environ.get("FAKE_CDP_VERSION", "2")),
+                  "input_settle": input_settle, "target_id": target, "port": 9222}), flush=True)
 values = {}
 url = "about:blank"
 for line in sys.stdin:
@@ -34,6 +43,9 @@ for line in sys.stdin:
     elif command == "url":
         data = url
     elif command == "eval":
+        data = ({"href": url, "timeOrigin": 1}
+                if "performance.timeOrigin" in args[0] else True)
+    elif command == "wait":
         data = True
     elif command == "console":
         data = []

--- a/tests/fixtures/live-flow.yaml
+++ b/tests/fixtures/live-flow.yaml
@@ -16,4 +16,6 @@ scenarios:
         capture: false
       - action: click
         target: "#save"
+        wait: "fn:document.querySelector('#status').textContent.startsWith('saved')"
         assert: {target: "#status", contains: "saved"}
+        capture: true

--- a/tests/fixtures/live-page.html
+++ b/tests/fixtures/live-page.html
@@ -6,7 +6,15 @@
 <p id="status">not saved</p>
 <script>
 document.getElementById('save').addEventListener('click', function (event) {
-  document.getElementById('status').textContent =
-    (event.isTrusted ? 'saved ' : 'untrusted ') + document.getElementById('name').value;
+  var trusted = event.isTrusted;
+  setTimeout(function () {
+    document.getElementById('status').textContent =
+      (trusted ? 'saved ' : 'untrusted ') + document.getElementById('name').value;
+  }, 300);
+});
+document.getElementById('name').addEventListener('input', function (event) {
+  var value = event.target.value;
+  event.target.value = 'normalizing';
+  setTimeout(function () { event.target.value = value; }, 150);
 });
 </script>

--- a/tests/test-flow-runner-live.sh
+++ b/tests/test-flow-runner-live.sh
@@ -61,13 +61,50 @@ done
 
 TARGET_ID="$("${PY}" "${CDP}" newtab "http://127.0.0.1:${HTTP_PORT}/live-page.html?job=runner-live")"
 VARS="$(printf '{"base_url":"http://127.0.0.1:%s/live-page.html","tester":"s3cret-Ada"}' "${HTTP_PORT}")"
-printf '%s' "${VARS}" | "${PY}" "${ROOT}/scripts/flow-runner.py" \
-  --flow "${ROOT}/tests/fixtures/live-flow.yaml" --out "${WORK}/out" --vars-json - \
-  --target-id "${TARGET_ID}" --cdp-script "${CDP}"
+LIVE_RUNS="${LIVE_RUNS:-1}"
+[[ "${LIVE_RUNS}" =~ ^[0-9]+$ ]] && [ "${LIVE_RUNS}" -ge 1 ] && [ "${LIVE_RUNS}" -le 50 ] \
+  || { echo "FAIL: LIVE_RUNS must be an integer in 1..50"; exit 2; }
+for run in $(seq 1 "${LIVE_RUNS}"); do
+  printf '%s' "${VARS}" | "${PY}" "${ROOT}/scripts/flow-runner.py" \
+    --flow "${ROOT}/tests/fixtures/live-flow.yaml" --out "${WORK}/out-${run}" --vars-json - \
+    --target-id "${TARGET_ID}" --cdp-script "${CDP}" >"${WORK}/runner-${run}.jsonl"
+done
 
-grep -q '"verdict":"PASS"' "${WORK}/out/run-log.jsonl"
 grep -q 'event.isTrusted' "${ROOT}/tests/fixtures/live-page.html"
-[ -s "${WORK}/out/shots/native-click-03.png" ]
-if grep -q 's3cret-Ada' "${WORK}/out/run-log.jsonl"; then exit 1; fi
-if grep -q 's3cret-Ada' "${WORK}/out/qa-report.md"; then exit 1; fi
-echo "PASS: real Chrome flow used native click, one pinned JSONL session, redacted secret, and artifacts"
+[ -s "${WORK}/out-1/shots/native-click-03.png" ]
+"${PY}" - "${WORK}" "${LIVE_RUNS}" <<'PY'
+import json
+import statistics
+import sys
+from pathlib import Path
+
+work, count = Path(sys.argv[1]), int(sys.argv[2])
+rows = []
+for run in range(1, count + 1):
+    events = [json.loads(line) for line in
+              (work / f"out-{run}" / "run-log.jsonl").read_text(encoding="utf-8").splitlines()]
+    ready = next(item for item in events if item["type"] == "session_ready")
+    assert ready["version"] >= 2 and ready["input_settle"] == "none", ready
+    steps = [item for item in events if item["type"] == "step_done"]
+    assert len(steps) == 3 and all(item["status"] != "fail" for item in steps), steps
+    fill = steps[1]["timings"]["phases"]
+    click = steps[2]["timings"]["phases"]
+    assert fill["wait"]["wall_ms"] >= 100, fill
+    assert click["wait"]["driver_ms"] >= 250, click
+    assert fill["action"]["driver_ms"] < fill["wait"]["wall_ms"], fill
+    assert click["action"]["driver_ms"] < click["wait"]["driver_ms"], click
+    assert "assert" in click and "capture" in click, click
+    assert next(item for item in events if item["type"] == "errors").get("timing"), events
+    done = next(item for item in events if item["type"] == "run_done")
+    assert done["verdict"] == "PASS", done
+    rows.append({"startup_ms": done["startup_ms"], "open_ms": steps[0]["duration_ms"],
+                 "fill_ms": steps[1]["duration_ms"], "click_ms": steps[2]["duration_ms"],
+                 "step_total_ms": sum(item["duration_ms"] for item in steps),
+                 "run_total_ms": done["duration_ms"]})
+print(json.dumps({"runs": count, "failures": 0,
+                  "median_ms": {key: round(statistics.median(row[key] for row in rows), 3)
+                                for key in rows[0]}}, separators=(",", ":")))
+PY
+if grep -R -q 's3cret-Ada' "${WORK}"/out-*/run-log.jsonl; then exit 1; fi
+if grep -R -q 's3cret-Ada' "${WORK}"/out-*/qa-report.md; then exit 1; fi
+echo "PASS: ${LIVE_RUNS} real-Chrome run(s) used protocol v2, event-bound nav, fast native input, async waits, redaction, telemetry, and artifacts"

--- a/tests/test_flow_runner.py
+++ b/tests/test_flow_runner.py
@@ -35,7 +35,8 @@ class FlowRunnerTests(unittest.TestCase):
         self.addCleanup(shutil.rmtree, root, True)
         return root
 
-    def run_flow(self, yaml_text: str, variables: dict | None = None):
+    def run_flow(self, yaml_text: str, variables: dict | None = None,
+                 env_overrides: dict[str, str] | None = None):
         root = self.workspace()
         flow = root / "flow.yaml"
         flow.write_text(textwrap.dedent(yaml_text), encoding="utf-8")
@@ -43,6 +44,7 @@ class FlowRunnerTests(unittest.TestCase):
         counter = root / "starts.txt"
         env = os.environ.copy()
         env["FAKE_CDP_COUNTER"] = str(counter)
+        env.update(env_overrides or {})
         process = subprocess.run(
             [sys.executable, str(RUNNER), "--flow", str(flow), "--out", str(out),
              "--vars-json", "-", "--target-id", "target-123", "--cdp-script", str(FAKE_CDP)],
@@ -72,6 +74,17 @@ class FlowRunnerTests(unittest.TestCase):
         report = (out / "qa-report.md").read_text(encoding="utf-8")
         self.assertNotIn("do-not-leak", process.stdout + events + report)
         self.assertIn('"verdict":"PASS"', events)
+        payloads = [json.loads(line) for line in events.splitlines()]
+        ready = next(item for item in payloads if item["type"] == "session_ready")
+        self.assertEqual(2, ready["version"])
+        self.assertEqual("none", ready["input_settle"])
+        self.assertGreaterEqual(ready["duration_ms"], 0)
+        steps = [item for item in payloads if item["type"] == "step_done"]
+        self.assertTrue(all("timings" in item for item in steps))
+        self.assertIn("action", steps[1]["timings"]["phases"])
+        self.assertIn("wait", steps[1]["timings"]["phases"])
+        self.assertIn("assert", steps[2]["timings"]["phases"])
+        self.assertIn("timing", next(item for item in payloads if item["type"] == "errors"))
 
     def test_unasserted_click_is_unverified(self):
         process, out, _ = self.run_flow("""
@@ -138,6 +151,72 @@ class FlowRunnerTests(unittest.TestCase):
         )
         self.assertEqual(2, process.returncode)
         self.assertIn("SECRET_IN_ARGV", process.stdout)
+
+    def test_old_driver_is_rejected_with_actionable_error(self):
+        process, out, _ = self.run_flow("""
+            story: old-driver
+            title: Old driver
+            scenarios:
+              - id: smoke
+                steps:
+                  - {action: open, target: "https://example.test", capture: false}
+        """, env_overrides={"FAKE_CDP_VERSION": "1"})
+        self.assertEqual(1, process.returncode)
+        events = (out / "run-log.jsonl").read_text(encoding="utf-8")
+        self.assertIn("DRIVER_INCOMPATIBLE", events)
+        self.assertIn("v2+", events)
+
+    def test_driver_rejecting_fast_policy_is_mapped_to_incompatible(self):
+        process, out, _ = self.run_flow("""
+            story: rejected-policy
+            title: Rejected policy
+            scenarios:
+              - id: smoke
+                steps:
+                  - {action: open, target: "https://example.test", capture: false}
+        """, env_overrides={"FAKE_CDP_REJECT_INPUT_SETTLE": "1"})
+        self.assertEqual(1, process.returncode)
+        self.assertIn("DRIVER_INCOMPATIBLE",
+                      (out / "run-log.jsonl").read_text(encoding="utf-8"))
+
+    def test_capture_defaults_follow_doc_mode_and_failure_evidence(self):
+        passed, passed_out, _ = self.run_flow("""
+            story: capture-policy
+            title: Capture policy
+            scenarios:
+              - id: adversarial-pass
+                doc: false
+                steps:
+                  - action: click
+                    target: "#save"
+                    assert: {target: "#notice", contains: "saved"}
+              - id: guide-pass
+                doc: true
+                steps:
+                  - {action: open, target: "https://example.test"}
+        """)
+        self.assertEqual(0, passed.returncode, passed.stdout + passed.stderr)
+        shots = sorted(path.name for path in (passed_out / "shots").glob("*.png"))
+        self.assertEqual(["guide-pass-01.png"], shots)
+
+        failed, failed_out, _ = self.run_flow("""
+            story: failure-evidence
+            title: Failure evidence
+            scenarios:
+              - id: adversarial-fail
+                doc: false
+                steps:
+                  - action: click
+                    target: "#save"
+                    assert: {target: "#notice", contains: "missing"}
+        """)
+        self.assertEqual(1, failed.returncode)
+        self.assertTrue((failed_out / "shots" / "adversarial-fail-01-failure.png").is_file())
+        payloads = [json.loads(line) for line in
+                    (failed_out / "run-log.jsonl").read_text(encoding="utf-8").splitlines()]
+        step = next(item for item in payloads if item["type"] == "step_done")
+        self.assertEqual("assert", step["timings"]["failing_phase"])
+        self.assertIn("capture", step["timings"]["phases"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Dependency
Requires Teibto/teibto-dev-standards#260 (CDP JSONL session protocol v2). Do not merge this PR before the driver PR is merged and released.

## Summary
- negotiate protocol v2 and the bounded input-settle=none policy at session startup
- replace fixed open settling with event-bound load completion
- add bounded fill/click outcome polling while preserving iframe semantics
- split authoritative driver duration from runner wall time and expose per-phase attempts/commands
- align success/failure evidence capture with the documented policy
- update the skill, reliability guidance, live fixtures, and release notes

## Benchmark
Same-machine live fixture:
- baseline: 5 isolated runs on main, median step flow 4,373.865 ms
- candidate: 20 fresh child sessions using a shared Chrome target, median step flow 622.523 ms
- improvement: 85.8%
- failures/false passes: 0/20

Candidate medians: startup 181.014 ms, open 30.552 ms, fill 171.488 ms, click 396.767 ms, total run 823.390 ms.

## Validation
- unit tests: 17 passed
- live benchmark: 20 passed, 0 failed
- canonical CDP smoke tests: 41 passed, 0 failed
- skill validation and package build
- shellcheck and Python compile
- gitleaks: no findings

## Independent review
Claude Fable reviewed only the relevant no-secret source and benchmark in read-only plan mode. Its FIX-THEN-ADOPT objections were independently verified and addressed: navigation is event-bound, readiness cannot read the old document, input waits are bounded, pick/lens retain fixed settling, iframe failures remain typed, and telemetry distinguishes driver duration from runner wall time.

Closes #52