### PR TITLE
fix(tests): print runner log when the live test fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- `tests/test-flow-runner-live.sh` พิมพ์ run-log ของ runner พร้อม path ของ driver ก่อน exit 1 เมื่อ runner
+  ล้ม แทนการออกเงียบ ๆ หลัง cleanup ลบ log ทิ้ง (#57)
+
 ## [2.2.0] - 2026-08-22
 
 **Current v2 browser guidance with stale transport history and unsupported flow examples removed.**

--- a/tests/test-flow-runner-live.sh
+++ b/tests/test-flow-runner-live.sh
@@ -65,9 +65,16 @@ LIVE_RUNS="${LIVE_RUNS:-1}"
 [[ "${LIVE_RUNS}" =~ ^[0-9]+$ ]] && [ "${LIVE_RUNS}" -ge 1 ] && [ "${LIVE_RUNS}" -le 50 ] \
   || { echo "FAIL: LIVE_RUNS must be an integer in 1..50"; exit 2; }
 for run in $(seq 1 "${LIVE_RUNS}"); do
+  # Print the runner log on failure: cleanup removes ${WORK}, so a silent exit would hide the cause
+  # (for example DRIVER_INCOMPATIBLE from a stale cdp.py).
   printf '%s' "${VARS}" | "${PY}" "${ROOT}/scripts/flow-runner.py" \
     --flow "${ROOT}/tests/fixtures/live-flow.yaml" --out "${WORK}/out-${run}" --vars-json - \
-    --target-id "${TARGET_ID}" --cdp-script "${CDP}" >"${WORK}/runner-${run}.jsonl"
+    --target-id "${TARGET_ID}" --cdp-script "${CDP}" >"${WORK}/runner-${run}.jsonl" || {
+    code=$?
+    echo "FAIL: runner exit ${code} on run ${run} (driver: ${CDP})"
+    cat "${WORK}/runner-${run}.jsonl"
+    exit 1
+  }
 done
 
 grep -q 'event.isTrusted' "${ROOT}/tests/fixtures/live-page.html"


### PR DESCRIPTION
## สรุป

`tests/test-flow-runner-live.sh` ออกเงียบ ๆ (exit 1, ไม่มี output) เมื่อ runner ล้ม เพราะ `set -e` หยุดทันทีและ `cleanup` ลบ `${WORK}` ที่เก็บ `runner-N.jsonl` ไว้. PR นี้จับ exit code ของ runner แล้วพิมพ์ `FAIL: runner exit <code> (driver: <path>)` ตามด้วยเนื้อหา run-log ก่อน exit 1.

## ตรวจแล้ว

- driver v1 (stale): พิมพ์ `FAIL: runner exit 1 ...` + `DRIVER_INCOMPATIBLE` event แล้ว exit 1
- driver v2 (origin/main ของ teibto-dev-standards): `PASS: 1 real-Chrome run(s) ...`
- `bash -n`, `shellcheck` ผ่าน

Fixes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)