### PR TITLE
feat(runner): report the resolved cdp.py path in driver errors and session_ready

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@
 
 ## [Unreleased]
 
+### Added
+
+- `session_ready.cdp_script` และข้อความ `DRIVER_INCOMPATIBLE`/`CDP_NOT_READY`/`TARGET_MISMATCH`
+  ระบุ path ของ `cdp.py` ที่ runner resolve ได้ เพื่อชี้สำเนาที่ต้องอัปเดตเมื่อเครื่องมี driver หลายชุด (#58)
+
 ## [2.2.0] - 2026-08-22
 
 **Current v2 browser guidance with stale transport history and unsupported flow examples removed.**

--- a/references/flow-spec.md
+++ b/references/flow-spec.md
@@ -80,7 +80,9 @@ Oracle JET ให้ใช้ selector หรือ `fn:<observable outcome>` �
 
 `run-log.jsonl` เก็บ runner wall-clock และ authoritative driver `duration_ms`/`attempts` แยก
 `action`, `wait`, `assert`, `capture`; failure มี partial phases + `failing_phase`, console check มี
-timing ของตัวเอง และ `run_done` แยก startup/total.
+timing ของตัวเอง และ `run_done` แยก startup/total. `session_ready.cdp_script` และข้อความ
+`DRIVER_INCOMPATIBLE`/`CDP_NOT_READY` ระบุ path ของ `cdp.py` ที่ runner resolve ได้จริง เพื่อให้รู้ว่า
+ต้องอัปเดตสำเนาไหนเมื่อเครื่องมี driver หลายชุด.
 
 **Traceability (สำหรับทีม):** `ticket`/`requirement` + `acceptance` ทำให้ตอบได้ว่า *test นี้ยืนยัน
 req ไหน* และ *req นี้ครอบด้วย scenario ไหน*. 1 acceptance criterion → 1 scenario (map 1:1) →

--- a/scripts/flow-runner.py
+++ b/scripts/flow-runner.py
@@ -168,6 +168,7 @@ class CDPSession:
                  request_timeout: float = 45.0):
         if not target_id:
             raise RunnerError("UNPINNED_TARGET", "ต้องระบุ --target-id หรือ TGT_ID")
+        self.script = script
         command = [
             sys.executable,
             str(script),
@@ -207,10 +208,11 @@ class CDPSession:
                 raise RunnerError(
                     "DRIVER_INCOMPATIBLE",
                     f"cdp.py เก่าเกินไป: runner ต้องใช้ {SESSION_PROTOCOL} v{MIN_SESSION_VERSION}+ "
-                    f"ที่รองรับ --input-settle={INPUT_SETTLE_POLICY}",
+                    f"ที่รองรับ --input-settle={INPUT_SETTLE_POLICY} (driver: {script})",
                     detail=ready,
                 )
-            raise RunnerError(error.get("code", "CDP_NOT_READY"), message, detail=ready)
+            raise RunnerError(error.get("code", "CDP_NOT_READY"),
+                              f"{message} (driver: {script})", detail=ready)
         version = ready.get("version")
         if (ready.get("protocol") != SESSION_PROTOCOL or not isinstance(version, int)
                 or version < MIN_SESSION_VERSION
@@ -219,12 +221,12 @@ class CDPSession:
             raise RunnerError(
                 "DRIVER_INCOMPATIBLE",
                 f"runner ต้องใช้ {SESSION_PROTOCOL} v{MIN_SESSION_VERSION}+ "
-                f"และ input_settle={INPUT_SETTLE_POLICY}",
+                f"และ input_settle={INPUT_SETTLE_POLICY} (driver: {script})",
                 detail=ready,
             )
         if ready.get("target_id") != target_id:
             self.close(force=True)
-            raise RunnerError("TARGET_MISMATCH", "CDP ต่อผิด target", detail=ready)
+            raise RunnerError("TARGET_MISMATCH", f"CDP ต่อผิด target (driver: {script})", detail=ready)
         self.ready = ready
 
     def _read_stdout(self) -> None:
@@ -523,6 +525,7 @@ def run_flow(flow: dict[str, Any], path: Path, output_dir: Path, variables: dict
         session = CDPSession(cdp_script, target_id, port=port)
         startup_ms = round((time.perf_counter() - startup_started) * 1000, 3)
         sink.emit({"type": "session_ready", "target_id": target_id,
+                   "cdp_script": str(session.script),
                    "protocol": session.ready.get("protocol"),
                    "version": session.ready.get("version"),
                    "input_settle": session.ready.get("input_settle"),

--- a/tests/test_flow_runner.py
+++ b/tests/test_flow_runner.py
@@ -78,6 +78,7 @@ class FlowRunnerTests(unittest.TestCase):
         ready = next(item for item in payloads if item["type"] == "session_ready")
         self.assertEqual(2, ready["version"])
         self.assertEqual("none", ready["input_settle"])
+        self.assertEqual(str(FAKE_CDP), ready["cdp_script"])
         self.assertGreaterEqual(ready["duration_ms"], 0)
         steps = [item for item in payloads if item["type"] == "step_done"]
         self.assertTrue(all("timings" in item for item in steps))
@@ -165,6 +166,9 @@ class FlowRunnerTests(unittest.TestCase):
         events = (out / "run-log.jsonl").read_text(encoding="utf-8")
         self.assertIn("DRIVER_INCOMPATIBLE", events)
         self.assertIn("v2+", events)
+        fatal = next(json.loads(line) for line in events.splitlines()
+                     if '"type":"fatal"' in line)
+        self.assertIn(str(FAKE_CDP), fatal["error"]["message"])
 
     def test_driver_rejecting_fast_policy_is_mapped_to_incompatible(self):
         process, out, _ = self.run_flow("""


### PR DESCRIPTION
## สรุป

`resolve_cdp_script` เลือก cdp.py จาก 4 candidate แต่เมื่อ driver เก่า/ไม่พร้อม ข้อความไม่บอกว่าใช้ไฟล์ไหน — บนเครื่องที่มีสำเนาหลายชุด (sibling repo, skill `netsuite-qa-browser`) ผู้ใช้ไม่รู้ว่าต้องอัปเดตชุดใด.

- `CDPSession` เก็บ `script` และต่อท้าย `(driver: <path>)` ใน `DRIVER_INCOMPATIBLE`, `CDP_NOT_READY`, `TARGET_MISMATCH`
- `session_ready` เพิ่ม `cdp_script`
- tests: `test_pass_*` ตรวจ `cdp_script`; `test_old_driver_*` ตรวจว่า path อยู่ในข้อความ fatal
- flow-spec.md + CHANGELOG

## ตรวจแล้ว

- `python -m unittest discover -s tests` → 18 OK
- `python scripts/validate-skill.py` → PASS

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)