### PR TITLE
fix(ui): run any flow that lists, including .yml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
 
 ### Fixed
 
+- local UI: flow `.yml` ที่ `/api/stories` list ได้ สั่ง `POST /api/run` แล้วไม่ 404 อีก — `startRun` ใช้ resolver
+  เดียวกับ `metadata()` (#59)
 - `tests/test-flow-runner-live.sh` พิมพ์ run-log ของ runner พร้อม path ของ driver ก่อน exit 1 เมื่อ runner
   ล้ม แทนการออกเงียบ ๆ หลัง cleanup ลบ log ทิ้ง (#57)
 

--- a/app/server.js
+++ b/app/server.js
@@ -57,11 +57,16 @@ async function flowFiles() {
   return names.filter(name => /\.ya?ml$/i.test(name)).sort();
 }
 
-async function metadata(id, full = false) {
+// One resolver for every id-addressed endpoint, so a flow that lists (.yaml or .yml) also runs.
+async function flowPath(id) {
   safeId(id, "flow id");
   const candidates = (await flowFiles()).filter(name => path.parse(name).name === id);
   if (candidates.length !== 1) throw Object.assign(new Error("flow not found"), {status: 404});
-  return childJson(["--flow", path.join(FLOWS, candidates[0]), "--meta", ...(full ? ["--full"] : [])]);
+  return path.join(FLOWS, candidates[0]);
+}
+
+async function metadata(id, full = false) {
+  return childJson(["--flow", await flowPath(id), "--meta", ...(full ? ["--full"] : [])]);
 }
 
 function readBody(req) {
@@ -90,7 +95,7 @@ function publish(run, event) {
   for (const client of run.clients) client.write(line);
 }
 
-function startRun(body) {
+async function startRun(body) {
   const flow = safeId(body.flow, "flow");
   const targetId = body.target_id || process.env.TGT_ID;
   if (!targetId || typeof targetId !== "string") throw Object.assign(new Error("target_id is required"), {status: 400});
@@ -98,9 +103,7 @@ function startRun(body) {
     throw Object.assign(new Error("vars must be an object"), {status: 400});
   }
   const runId = `${Date.now()}-${crypto.randomBytes(4).toString("hex")}`;
-  const flowPath = path.join(FLOWS, `${flow}.yaml`);
-  if (!fs.existsSync(flowPath)) throw Object.assign(new Error("flow not found"), {status: 404});
-  const args = ["--flow", flowPath, "--out", path.join(RUNS, runId), "--vars-json", "-", "--target-id", targetId];
+  const args = ["--flow", await flowPath(flow), "--out", path.join(RUNS, runId), "--vars-json", "-", "--target-id", targetId];
   if (process.env.TEIBTO_CDP_SCRIPT) args.push("--cdp-script", process.env.TEIBTO_CDP_SCRIPT);
   if (process.env.CDP_PORT) args.push("--cdp-port", process.env.CDP_PORT);
   const child = spawn(PYTHON, [RUNNER, ...args], {cwd: ROOT, windowsHide: true, stdio: ["pipe", "pipe", "pipe"]});
@@ -172,7 +175,7 @@ async function handler(req, res) {
   }
   if (req.method === "POST" && url.pathname === "/api/run") {
     const body = await readBody(req);
-    return json(res, 202, {run_id: startRun(body)});
+    return json(res, 202, {run_id: await startRun(body)});
   }
   match = url.pathname.match(/^\/api\/events\/([A-Za-z0-9-]+)$/);
   if (match && req.method === "GET") {

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -5,6 +5,7 @@ import os
 import shutil
 import socket
 import subprocess
+import textwrap
 import time
 import unittest
 import urllib.error
@@ -14,6 +15,8 @@ from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parent.parent
+FAKE_CDP = ROOT / "tests" / "fixtures" / "fake_cdp.py"
+EXAMPLES = ROOT / "examples"
 
 
 @unittest.skipUnless(shutil.which("node"), "Node.js is not installed")
@@ -25,6 +28,7 @@ class LocalServerTests(unittest.TestCase):
             cls.port = sock.getsockname()[1]
         env = os.environ.copy()
         env["QA_PORT"] = str(cls.port)
+        env["TEIBTO_CDP_SCRIPT"] = str(FAKE_CDP)
         env.pop("TGT_ID", None)
         cls.process = subprocess.Popen(
             ["node", str(ROOT / "app" / "server.js")], cwd=ROOT, env=env,
@@ -83,6 +87,32 @@ class LocalServerTests(unittest.TestCase):
         self.assertEqual(400, caught.exception.code)
         body = json.loads(caught.exception.read())
         self.assertIn("target_id", body["error"])
+
+    def test_yml_flow_that_lists_also_runs(self) -> None:
+        flow = EXAMPLES / "zz-server-test-yml.yml"
+        flow.write_text(textwrap.dedent("""
+            story: zz-server-test-yml
+            title: YML flow
+            scenarios:
+              - id: smoke
+                steps:
+                  - {action: open, target: "https://example.test", capture: false}
+            """), encoding="utf-8")
+        self.addCleanup(flow.unlink, missing_ok=True)
+        request = urllib.request.Request(
+            f"http://127.0.0.1:{self.port}/api/run",
+            data=json.dumps({"flow": "zz-server-test-yml", "target_id": "target-123"}).encode(),
+            headers={"Content-Type": "application/json"}, method="POST",
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=10) as response:
+                self.assertEqual(202, response.status)
+                self.assertIn("run_id", json.load(response))
+        except urllib.error.HTTPError as error:
+            body = json.loads(error.read())
+            if error.code == 500 and "spawn EPERM" in body.get("error", ""):
+                self.skipTest("managed Windows sandbox blocks Node child_process.spawn")
+            self.fail(f"{error.code}: {body}")
 
     def test_path_traversal_is_not_served(self) -> None:
         with self.assertRaises(urllib.error.HTTPError) as caught:


### PR DESCRIPTION
## สรุป

`flowFiles()` list ทั้ง `.yaml`/`.yml` และ `metadata()` หาไฟล์จาก basename แต่ `startRun()` ประกอบ path เป็น `${flow}.yaml` ตายตัว → flow `.yml` เปิดดูได้แต่ `POST /api/run` ได้ 404.

- รวมเป็น `flowPath(id)` ตัวเดียว ใช้ทั้ง `metadata()` และ `startRun()` (startRun กลายเป็น async)
- test `test_yml_flow_that_lists_also_runs`: สร้าง `examples/zz-server-test-yml.yml` ชั่วคราว → `POST /api/run` ต้องได้ 202 (server test ตั้ง `TEIBTO_CDP_SCRIPT=fake_cdp.py`)

## ตรวจแล้ว

- test ใหม่ fail บน `server.js` เดิม (`404 flow not found`) และผ่านบนของใหม่
- `python -m unittest tests.test_server` → 6 OK, `node --check` OK

Fixes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)