### PR TITLE
fix(ui): keep /api/stories usable when one flow fails to load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
 
 ### Fixed
 
+- local UI: `GET /api/stories` ตอบ 200 เสมอเมื่ออ่าน `examples/` ได้ — flow ที่โหลดไม่ได้คืน item พร้อม `error`
+  แทนการทำทั้งรายการเป็น 500 (#60)
 - local UI: flow `.yml` ที่ `/api/stories` list ได้ สั่ง `POST /api/run` แล้วไม่ 404 อีก — `startRun` ใช้ resolver
   เดียวกับ `metadata()` (#59)
 - `tests/test-flow-runner-live.sh` พิมพ์ run-log ของ runner พร้อม path ของ driver ก่อน exit 1 เมื่อ runner

--- a/app/server.js
+++ b/app/server.js
@@ -163,8 +163,13 @@ async function handler(req, res) {
     return json(res, 200, {ok: true, runner: "cdp-jsonl", target_pinned: Boolean(process.env.TGT_ID), record: false});
   }
   if (req.method === "GET" && url.pathname === "/api/stories") {
+    // One unreadable flow must not blank the whole list: report it per item (the UI renders `error`).
     const items = [];
-    for (const file of await flowFiles()) items.push(await metadata(path.parse(file).name));
+    for (const file of await flowFiles()) {
+      const id = path.parse(file).name;
+      try { items.push(await metadata(id)); }
+      catch (error) { items.push({id, file, title: id, target: "web", error: error.message}); }
+    }
     return json(res, 200, items);
   }
   let match = url.pathname.match(/^\/api\/stories\/([A-Za-z0-9_-]+)$/);

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -88,6 +88,24 @@ class LocalServerTests(unittest.TestCase):
         body = json.loads(caught.exception.read())
         self.assertIn("target_id", body["error"])
 
+    def test_one_broken_flow_does_not_blank_the_story_list(self) -> None:
+        broken = EXAMPLES / "zz-server-test-broken.yaml"
+        broken.write_text("story: zz-server-test-broken", encoding="utf-8")
+        self.addCleanup(broken.unlink, missing_ok=True)
+        try:
+            status, body = self.get_json("/api/stories")
+        except urllib.error.HTTPError as error:
+            detail = json.loads(error.read())
+            if error.code == 500 and "spawn EPERM" in detail.get("error", ""):
+                self.skipTest("managed Windows sandbox blocks Node child_process.spawn")
+            self.fail(f"{error.code}: {detail}")
+        self.assertEqual(200, status)
+        by_id = {item["id"]: item for item in body}
+        self.assertIn("saucedemo", by_id)
+        self.assertNotIn("error", by_id["saucedemo"])
+        self.assertIn("schema", by_id["zz-server-test-broken"]["error"])
+        self.assertEqual("zz-server-test-broken.yaml", by_id["zz-server-test-broken"]["file"])
+
     def test_yml_flow_that_lists_also_runs(self) -> None:
         flow = EXAMPLES / "zz-server-test-yml.yml"
         flow.write_text(textwrap.dedent("""


### PR DESCRIPTION
## สรุป

`GET /api/stories` `await metadata()` ทีละไฟล์โดยไม่ catch → YAML ที่ไม่ผ่าน schema ไฟล์เดียวทำให้ทั้งรายการเป็น 500 และหน้า Stories/Run ว่างทั้งหน้า.

- ไฟล์ที่โหลดไม่ได้คืน `{id, file, title, target, error}` (UI `renderStoryList` รองรับ `s.error` อยู่แล้ว) และรายการอื่นยังใช้ได้
- test `test_one_broken_flow_does_not_blank_the_story_list`: สร้าง `examples/zz-server-test-broken.yaml` ชั่วคราว → 200, `saucedemo` ไม่มี `error`, ไฟล์พังมี `error` ที่มีคำว่า schema

## ตรวจแล้ว

- test ใหม่ fail บน server.js ก่อนหน้า (500 + `INVALID_FLOW`) และผ่านบนของใหม่
- `python -m unittest tests.test_server` → 7 OK, `node --check` OK

Fixes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)