### PR TITLE
fix(runner): record auto-answered dialogs as evidence and pin DIALOG=safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@
 
 ### Fixed
 
+- runner บันทึก dialog ที่ cdp.py ตอบอัตโนมัติทุกรายการเป็น event `dialog` ใน run-log + บรรทัด ⚠️ และสรุป
+  `Auto-answered dialogs` ใน qa-report; session ได้ `DIALOG=safe` เสมอ (ไม่ inherit จาก shell) เปลี่ยนได้
+  เฉพาะ `--dialog accept|dismiss` และ policy ที่ใช้อยู่ใน `run_start.driver_policy.dialog` (#56)
 - local UI: `GET /api/stories` ตอบ 200 เสมอเมื่ออ่าน `examples/` ได้ — flow ที่โหลดไม่ได้คืน item พร้อม `error`
   แทนการทำทั้งรายการเป็น 500 (#60)
 - local UI: flow `.yml` ที่ `/api/stories` list ได้ สั่ง `POST /api/run` แล้วไม่ 404 อีก — `startRun` ใช้ resolver

--- a/README.md
+++ b/README.md
@@ -107,8 +107,9 @@ runs/manual/
 
 It validates the schema before opening the driver, refuses to guess a shared tab, negotiates protocol
 v2+, waits for the new main-frame document on navigation, polls bounded observable outcomes after fast
-inputs, redacts secret variables, and fails closed on command, wait, assertion, capture, console, or
-transport errors. An unasserted state-changing action is `UNVERIFIED`, never `PASS`.
+inputs, redacts secret variables, records every auto-answered dialog as evidence under a pinned
+`safe` dialog policy, and fails closed on command, wait, assertion, capture, console, or transport
+errors. An unasserted state-changing action is `UNVERIFIED`, never `PASS`.
 
 For the exact YAML, wait, capture, and telemetry contracts, read
 [`references/flow-spec.md`](references/flow-spec.md).

--- a/references/flow-spec.md
+++ b/references/flow-spec.md
@@ -20,6 +20,8 @@ $env:TEIBTO_CDP_SCRIPT = 'D:\path\to\teibto-dev-standards\scripts\cdp.py'
 - `open` รอ main-frame commit/load event จริง; ไม่ใช้ zero-drain + `readyState` ที่อาจอ่านหน้าเก่า
 - `click` ใช้ native input เท่านั้น; ไม่มี JS fallback เงียบ
 - action/wait/assert/screenshot/console ล้ม = หยุด scenario และ verdict `FAIL`
+- dialog ที่ driver ตอบอัตโนมัติทุกรายการถูกบันทึกเป็น event `dialog` ใน run-log และบรรทัด ⚠️ ใน report;
+  policy เป็น `safe` เสมอ (ไม่ inherit `DIALOG` จาก shell) เว้นแต่สั่ง `--dialog accept|dismiss`
 - action ที่เปลี่ยน state แต่ไม่มี explicit assertion = verdict `UNVERIFIED`, ไม่ใช่ `PASS`
 - artifact อยู่ที่ `<out>/run-log.jsonl`, `<out>/qa-report.md`, `<out>/shots/`
 
@@ -77,6 +79,15 @@ scenarios:
 action แล้วรอ URL/time origin เปลี่ยนพร้อม `readyState=complete`, จึงไม่ผ่านจากหน้าเก่า. งาน AJAX/
 Oracle JET ให้ใช้ selector หรือ `fn:<observable outcome>` เช่น
 `fn:document.querySelector('#status').textContent==='saved'` แล้ว assert ครั้งเดียว.
+
+Dialog: cdp.py พิมพ์ `[dialog] <kind>: <message> -> accept|dismiss` ลง stderr ทุกครั้งที่ตอบ dialog;
+runner แปลงเป็น event `{"type":"dialog","scenario","index","global_index","kind","message","answer","line"}`,
+นับรวมใน `run_done.dialogs` และสรุปใน report เป็น
+`**Auto-answered dialogs:** <n> (policy: <policy>)`. `run_start.driver_policy.dialog` บอก policy ที่ใช้จริง;
+default `safe` (alert = accept, อย่างอื่น = dismiss) และเปลี่ยนได้เฉพาะ `--dialog` ของ runner —
+QA run ไม่ inherit `DIALOG` จาก shell ตาม SKILL.md invariant 5. cdp.py v2 (v0.82) พิมพ์ ledger นี้ตอนปิด
+session จึงได้ event ที่ `scenario`/`index` เป็น `null` และหัวข้อ "Auto-answered dialogs (reported by
+the driver at session close)" ท้าย report; ถ้า driver รายงานระหว่าง step runner จะผูกกับ step นั้นให้เอง.
 
 `run-log.jsonl` เก็บ runner wall-clock และ authoritative driver `duration_ms`/`attempts` แยก
 `action`, `wait`, `assert`, `capture`; failure มี partial phases + `failing_phase`, console check มี

--- a/scripts/flow-runner.py
+++ b/scripts/flow-runner.py
@@ -44,6 +44,9 @@ MAX_EVENT_TEXT = 2_000
 SESSION_PROTOCOL = "teibto-cdp-jsonl"
 MIN_SESSION_VERSION = 2
 INPUT_SETTLE_POLICY = "none"
+DIALOG_POLICIES = ("safe", "accept", "dismiss")
+# cdp.py prints every auto-answered dialog to stderr as "[dialog] <kind>: <message> -> <answer>".
+DIALOG_LINE = re.compile(r"^\[dialog\] (?P<kind>[^:]+): (?P<message>.*) -> (?P<answer>\S+)$")
 
 
 class RunnerError(RuntimeError):
@@ -165,7 +168,7 @@ class EventSink:
 
 class CDPSession:
     def __init__(self, script: Path, target_id: str, *, port: str | None = None,
-                 request_timeout: float = 45.0):
+                 request_timeout: float = 45.0, dialog: str = "safe"):
         if not target_id:
             raise RunnerError("UNPINNED_TARGET", "ต้องระบุ --target-id หรือ TGT_ID")
         self.script = script
@@ -182,6 +185,8 @@ class CDPSession:
         env = os.environ.copy()
         if port:
             env["CDP_PORT"] = str(port)
+        # Never inherit a shell DIALOG override silently: the runner owns the dialog policy.
+        env["DIALOG"] = dialog
         self.process = subprocess.Popen(
             command,
             stdin=subprocess.PIPE,
@@ -196,9 +201,11 @@ class CDPSession:
         self.request_timeout = request_timeout
         self.lines: queue.Queue[str | None] = queue.Queue()
         self.stderr: list[str] = []
+        self.dialogs: queue.Queue[dict[str, str]] = queue.Queue()
         self.sequence = 0
         threading.Thread(target=self._read_stdout, daemon=True).start()
-        threading.Thread(target=self._read_stderr, daemon=True).start()
+        self._stderr_thread = threading.Thread(target=self._read_stderr, daemon=True)
+        self._stderr_thread.start()
         ready = self._next(request_timeout)
         if ready.get("type") != "ready" or not ready.get("ok"):
             error = ready.get("error") or {}
@@ -238,8 +245,23 @@ class CDPSession:
     def _read_stderr(self) -> None:
         assert self.process.stderr
         for line in self.process.stderr:
+            text = line.rstrip()
             if len(self.stderr) < 200:
-                self.stderr.append(line.rstrip())
+                self.stderr.append(text)
+            match = DIALOG_LINE.match(text)
+            if match:
+                self.dialogs.put({**match.groupdict(), "line": text})
+            elif text.startswith("[dialog]"):
+                self.dialogs.put({"kind": "unknown", "message": text, "answer": "unknown", "line": text})
+
+    def drain_dialogs(self) -> list[dict[str, str]]:
+        """Dialogs the driver answered since the previous drain (stderr arrives asynchronously)."""
+        items: list[dict[str, str]] = []
+        while True:
+            try:
+                items.append(self.dialogs.get_nowait())
+            except queue.Empty:
+                return items
 
     def _next(self, timeout: float) -> dict[str, Any]:
         try:
@@ -284,23 +306,28 @@ class CDPSession:
             return payload
 
     def close(self, *, force: bool = False) -> None:
-        if self.process.poll() is not None:
-            return
-        if not force:
-            try:
-                assert self.process.stdin
-                self.process.stdin.write('{"id":"runner-close","type":"close"}\n')
-                self.process.stdin.flush()
-                self.process.wait(timeout=3)
-                return
-            except Exception:
-                pass
-        self.process.terminate()
         try:
-            self.process.wait(timeout=3)
-        except subprocess.TimeoutExpired:
-            self.process.kill()
-            self.process.wait(timeout=3)
+            if self.process.poll() is not None:
+                return
+            if not force:
+                try:
+                    assert self.process.stdin
+                    self.process.stdin.write('{"id":"runner-close","type":"close"}\n')
+                    self.process.stdin.flush()
+                    self.process.wait(timeout=3)
+                    return
+                except Exception:
+                    pass
+            self.process.terminate()
+            try:
+                self.process.wait(timeout=3)
+            except subprocess.TimeoutExpired:
+                self.process.kill()
+                self.process.wait(timeout=3)
+        finally:
+            # cdp.py reports the dialogs it answered on stderr at close; make sure the reader
+            # has consumed that tail before the caller drains dialogs for the report.
+            self._stderr_thread.join(timeout=3)
 
 
 class StepTimings:
@@ -500,7 +527,8 @@ def flow_meta(flow: dict[str, Any], path: Path, *, full: bool = False) -> dict[s
 
 
 def run_flow(flow: dict[str, Any], path: Path, output_dir: Path, variables: dict[str, Any],
-             cdp_script: Path, target_id: str, port: str | None, sink: EventSink) -> int:
+             cdp_script: Path, target_id: str, port: str | None, sink: EventSink,
+             dialog: str = "safe") -> int:
     run_started = time.perf_counter()
     output_dir.mkdir(parents=True, exist_ok=True)
     shots = output_dir / "shots"
@@ -510,19 +538,30 @@ def run_flow(flow: dict[str, Any], path: Path, output_dir: Path, variables: dict
               f"**Target ID:** `{target_id}`", ""]
     assertions = sum(1 for scenario in flow["scenarios"] for step in scenario["steps"]
                      if step.get("assert"))
-    passed = failures = unverified = 0
+    passed = failures = unverified = dialogs = 0
     session: CDPSession | None = None
+
+    def flush_dialogs(scenario_id: str, index: int | None, global_index: int | None) -> None:
+        # Every auto-answered dialog is a (possible) mutation: it goes into run-log and report,
+        # attributed to the step during which the driver reported it.
+        nonlocal dialogs
+        for item in (session.drain_dialogs() if session else []):
+            dialogs += 1
+            sink.emit({"type": "dialog", "scenario": scenario_id, "index": index,
+                       "global_index": global_index, **item})
+            report.append(f"- ⚠️ dialog {item['kind']}: \"{item['message']}\" -> {item['answer']}")
     sink.emit({"type": "run_start", "story": flow["story"], "title": flow["title"],
                "driver_policy": {"protocol": SESSION_PROTOCOL,
                                  "min_version": MIN_SESSION_VERSION,
                                  "input_settle": INPUT_SETTLE_POLICY,
+                                 "dialog": dialog,
                                  "navigation": "event-bound-load"},
                "scenarios": [{"id": item["id"], "steps": len(item["steps"])}
                              for item in flow["scenarios"]]})
     startup_started = time.perf_counter()
     startup_ms: float | None = None
     try:
-        session = CDPSession(cdp_script, target_id, port=port)
+        session = CDPSession(cdp_script, target_id, port=port, dialog=dialog)
         startup_ms = round((time.perf_counter() - startup_started) * 1000, 3)
         sink.emit({"type": "session_ready", "target_id": target_id,
                    "cdp_script": str(session.script),
@@ -565,6 +604,7 @@ def run_flow(flow: dict[str, Any], path: Path, output_dir: Path, variables: dict
                         shot = str(shot_path)
                     marker = "✅" if status == "pass" else ("⚠️" if status == "unverified" else "▸")
                     report.append(f"- {marker} {intent}" + (f" — {detail}" if detail else ""))
+                    flush_dialogs(scenario["id"], index, global_index)
                     timing_payload = timings.payload()
                     sink.emit({"type": "step_done", "scenario": scenario["id"], "index": index,
                                "global_index": global_index, "intent": intent, "status": status,
@@ -584,6 +624,7 @@ def run_flow(flow: dict[str, Any], path: Path, output_dir: Path, variables: dict
                         except RunnerError as capture_exc:
                             evidence_error = {"code": capture_exc.code, "message": str(capture_exc)}
                     report.append(f"- ❌ {intent} — {exc.code}: {exc}")
+                    flush_dialogs(scenario["id"], index, global_index)
                     timing_payload = timings.payload()
                     sink.emit({"type": "step_done", "scenario": scenario["id"], "index": index,
                                "global_index": global_index, "intent": intent, "status": "fail",
@@ -627,6 +668,7 @@ def run_flow(flow: dict[str, Any], path: Path, output_dir: Path, variables: dict
                                    "attempts": detail.get("attempts"),
                                },
                                "error": {"code": exc.code, "message": str(exc)}})
+            flush_dialogs(scenario["id"], None, None)
             sink.emit({"type": "scenario_done", "id": scenario["id"],
                        "status": "fail" if scenario_failed else "done"})
             report.append("")
@@ -639,15 +681,28 @@ def run_flow(flow: dict[str, Any], path: Path, output_dir: Path, variables: dict
     finally:
         if session:
             session.close()
+            # Current cdp.py session mode prints its dialog ledger only at close, so these
+            # cannot be attributed to a step; they are still evidence and still counted.
+            late = session.drain_dialogs()
+            if late:
+                report.extend(["## Auto-answered dialogs (reported by the driver at session close)", ""])
+                for item in late:
+                    dialogs += 1
+                    sink.emit({"type": "dialog", "scenario": None, "index": None,
+                               "global_index": None, **item})
+                    report.append(f"- ⚠️ dialog {item['kind']}: \"{item['message']}\" -> {item['answer']}")
+                report.append("")
 
     verdict = "FAIL" if failures else ("UNVERIFIED" if unverified else "PASS")
     summary = [f"**Verdict:** {verdict}", f"**Assertions:** {passed}/{assertions} passed",
-               f"**Unverified state changes:** {unverified}", ""]
+               f"**Unverified state changes:** {unverified}",
+               f"**Auto-answered dialogs:** {dialogs} (policy: {dialog})", ""]
     report[4:4] = summary
     safe_report = redact("\n".join(report), sink.secrets, variables, truncate=False)
     report_path.write_text(str(safe_report), encoding="utf-8")
     sink.emit({"type": "run_done", "passed": passed, "total": assertions,
-               "failures": failures, "unverified": unverified, "verdict": verdict,
+               "failures": failures, "unverified": unverified, "dialogs": dialogs,
+               "verdict": verdict,
                "duration_ms": round((time.perf_counter() - run_started) * 1000, 3),
                "startup_ms": startup_ms,
                "report": str(report_path.resolve())})
@@ -675,6 +730,8 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--target-id", default=os.environ.get("TGT_ID"))
     parser.add_argument("--cdp-port", default=os.environ.get("CDP_PORT"))
     parser.add_argument("--cdp-script")
+    parser.add_argument("--dialog", choices=DIALOG_POLICIES, default="safe",
+                        help="dialog policy handed to cdp.py (default: safe; never inherited from env)")
     parser.add_argument("--meta", action="store_true")
     parser.add_argument("--full", action="store_true")
     args = parser.parse_args(argv)
@@ -703,7 +760,7 @@ def main(argv: list[str] | None = None) -> int:
         log_path = output_dir / "run-log.jsonl"
         sink = EventSink(sys.stdout, log_path, secret_names(flow), variables)
         return run_flow(flow, path, output_dir, variables, cdp_script,
-                        args.target_id or "", args.cdp_port, sink)
+                        args.target_id or "", args.cdp_port, sink, dialog=args.dialog)
     except RunnerError as exc:
         payload = {"type": "fatal", "error": {"code": exc.code, "message": str(exc)}}
         if sink:

--- a/tests/fixtures/fake_cdp.py
+++ b/tests/fixtures/fake_cdp.py
@@ -23,13 +23,38 @@ print(json.dumps({"type": "ready", "ok": True, "protocol": "teibto-cdp-jsonl",
                   "input_settle": input_settle, "target_id": target, "port": 9222}), flush=True)
 values = {}
 url = "about:blank"
+# FAKE_CDP_DIALOG=<kind>:<message> makes every click raise that dialog; the answer follows the
+# DIALOG policy the way cdp.py does (safe = dismiss anything that is not an alert). Like the
+# real driver the ledger is printed to stderr at close; FAKE_CDP_DIALOG_WHEN=click prints it
+# live instead (a future driver behaviour the runner attributes per step).
+dialog_spec = os.environ.get("FAKE_CDP_DIALOG")
+dialog_policy = os.environ.get("DIALOG", "safe")
+dialog_when = os.environ.get("FAKE_CDP_DIALOG_WHEN", "close")
+dialog_ledger = []
+
+
+def report_dialogs():
+    for line in dialog_ledger:
+        sys.stderr.write(line)
+    sys.stderr.flush()
+    dialog_ledger.clear()
 for line in sys.stdin:
     request = json.loads(line)
     if request.get("type") == "close":
         print(json.dumps({"type": "closed", "id": request.get("id"), "ok": True,
                           "reason": "requested", "target_id": target}), flush=True)
+        report_dialogs()
         break
     command, args = request["command"], request.get("args", [])
+    if command == "click" and dialog_spec:
+        kind, message = dialog_spec.split(":", 1)
+        if dialog_policy == "safe":
+            answer = "accept" if kind == "alert" else "dismiss"
+        else:
+            answer = dialog_policy
+        dialog_ledger.append(f"[dialog] {kind}: {message} -> {answer}\n")
+        if dialog_when == "click":
+            report_dialogs()
     if command == "nav":
         url = args[0]
         data = url

--- a/tests/test_flow_runner.py
+++ b/tests/test_flow_runner.py
@@ -36,7 +36,8 @@ class FlowRunnerTests(unittest.TestCase):
         return root
 
     def run_flow(self, yaml_text: str, variables: dict | None = None,
-                 env_overrides: dict[str, str] | None = None):
+                 env_overrides: dict[str, str] | None = None,
+                 extra_args: list[str] | None = None):
         root = self.workspace()
         flow = root / "flow.yaml"
         flow.write_text(textwrap.dedent(yaml_text), encoding="utf-8")
@@ -47,7 +48,8 @@ class FlowRunnerTests(unittest.TestCase):
         env.update(env_overrides or {})
         process = subprocess.run(
             [sys.executable, str(RUNNER), "--flow", str(flow), "--out", str(out),
-             "--vars-json", "-", "--target-id", "target-123", "--cdp-script", str(FAKE_CDP)],
+             "--vars-json", "-", "--target-id", "target-123", "--cdp-script", str(FAKE_CDP),
+             *(extra_args or [])],
             input=json.dumps(variables or {}), capture_output=True, text=True, encoding="utf-8", env=env,
         )
         return process, out, counter
@@ -182,6 +184,57 @@ class FlowRunnerTests(unittest.TestCase):
         self.assertEqual(1, process.returncode)
         self.assertIn("DRIVER_INCOMPATIBLE",
                       (out / "run-log.jsonl").read_text(encoding="utf-8"))
+
+    def test_auto_answered_dialogs_are_evidence_and_policy_is_pinned(self):
+        flow = """
+            story: dialogs
+            title: Dialogs
+            scenarios:
+              - id: delete
+                steps:
+                  - {action: open, target: "https://example.test", capture: false}
+                  - action: click
+                    target: "#delete"
+                    assert: {target: "#notice", contains: "saved"}
+                    capture: false
+        """
+        # A stale DIALOG=accept in the shell must not leak into the QA session. The current
+        # driver prints its dialog ledger at session close, so the evidence is run-level.
+        process, out, _ = self.run_flow(flow, env_overrides={
+            "FAKE_CDP_DIALOG": "confirm:Delete this record?", "DIALOG": "accept"})
+        self.assertEqual(0, process.returncode, process.stdout + process.stderr)
+        payloads = [json.loads(line) for line in
+                    (out / "run-log.jsonl").read_text(encoding="utf-8").splitlines()]
+        start = next(item for item in payloads if item["type"] == "run_start")
+        self.assertEqual("safe", start["driver_policy"]["dialog"])
+        dialog = next(item for item in payloads if item["type"] == "dialog")
+        self.assertEqual({"scenario": None, "index": None, "kind": "confirm",
+                          "message": "Delete this record?", "answer": "dismiss"},
+                         {key: dialog[key] for key in
+                          ("scenario", "index", "kind", "message", "answer")})
+        done = next(item for item in payloads if item["type"] == "run_done")
+        self.assertEqual(1, done["dialogs"])
+        report = (out / "qa-report.md").read_text(encoding="utf-8")
+        self.assertIn('dialog confirm: "Delete this record?" -> dismiss', report)
+        self.assertIn("**Auto-answered dialogs:** 1 (policy: safe)", report)
+
+        # A driver that reports dialogs while the step runs gets per-step attribution.
+        process, out, _ = self.run_flow(flow, env_overrides={
+            "FAKE_CDP_DIALOG": "confirm:Delete this record?", "FAKE_CDP_DIALOG_WHEN": "click"})
+        self.assertEqual(0, process.returncode, process.stdout + process.stderr)
+        payloads = [json.loads(line) for line in
+                    (out / "run-log.jsonl").read_text(encoding="utf-8").splitlines()]
+        dialog = next(item for item in payloads if item["type"] == "dialog")
+        self.assertEqual(("delete", 2, 2), (dialog["scenario"], dialog["index"], dialog["global_index"]))
+        self.assertEqual(1, next(item for item in payloads if item["type"] == "run_done")["dialogs"])
+
+        # The policy changes only through the explicit runner flag.
+        process, out, _ = self.run_flow(flow, env_overrides={
+            "FAKE_CDP_DIALOG": "confirm:Delete this record?"}, extra_args=["--dialog", "accept"])
+        self.assertEqual(0, process.returncode, process.stdout + process.stderr)
+        events = (out / "run-log.jsonl").read_text(encoding="utf-8")
+        self.assertIn('"answer":"accept"', events)
+        self.assertIn('"dialog":"accept"', events)
 
     def test_capture_defaults_follow_doc_mode_and_failure_evidence(self):
         passed, passed_out, _ = self.run_flow("""


### PR DESCRIPTION
## สรุป

cdp.py พิมพ์ `[dialog] <kind>: <message> -> <answer>` ลง stderr ทุก dialog ที่ตอบอัตโนมัติ แต่ runner ใช้ stderr แค่บรรทัดสุดท้ายตอน `SESSION_CLOSED` และส่ง env ของ shell (รวม `DIALOG=accept` ที่ค้าง) ให้ session ตรง ๆ → mutation จาก dialog หายจากหลักฐาน (ขัด SKILL.md invariant 5).

- `CDPSession` parse บรรทัด `[dialog]` จาก stderr เป็น queue; runner emit event `dialog` (`scenario/index/global_index/kind/message/answer/line`) + บรรทัด ⚠️ ใน report, นับใน `run_done.dialogs`, สรุป `**Auto-answered dialogs:** n (policy: p)`
- session ได้ `DIALOG=<policy ของ runner>` เสมอ — default `safe`, เปลี่ยนได้เฉพาะ `--dialog accept|dismiss`; policy ที่ใช้อยู่ใน `run_start.driver_policy.dialog`
- **ข้อจำกัดที่พบระหว่างทำ:** cdp.py v2 (v0.82) พิมพ์ ledger นี้ตอน `close()` เท่านั้น จึงผูกกับ step ไม่ได้ — runner join stderr reader หลังปิด session แล้วรายงานเป็น run-level (`scenario: null`) ใต้หัวข้อ "Auto-answered dialogs (reported by the driver at session close)"; ถ้า driver รายงานระหว่าง step (เสนอ upstream) จะผูกกับ step ให้เอง
- fake_cdp: `FAKE_CDP_DIALOG=<kind>:<message>` (ledger ตอน close เหมือนของจริง) + `FAKE_CDP_DIALOG_WHEN=click` (live); test ใหม่พิสูจน์ทั้ง pinned policy, `--dialog accept`, run-level และ per-step attribution
- flow-spec.md, README, CHANGELOG

## ตรวจแล้ว

- `python -m unittest discover -s tests` → 21 OK; `validate-skill.py` PASS
- real Chrome (headless) + cdp.py v2 + หน้า `confirm('Delete this record?')`:
  - shell `DIALOG=accept` + runner default → `answer: dismiss`, status `kept`, PASS, `dialogs: 1`
  - `--dialog accept` → `answer: accept`, status `deleted`, assertion FAIL, report มีหัวข้อ dialogs
- `tests/test-flow-runner-live.sh` → PASS

Fixes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)