### PR TITLE
feat(runner): add token-safe performance budgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 ### Added
 
+- Token-safe runner stdout (`--stdout summary`) preserves the complete `run-log.jsonl` while returning
+  only terminal output to agent context; step `perf_budget_ms` now fails closed on slow observable
+  outcomes and records budget evidence in JSONL/report artifacts (measured 87.5% fewer stdout tokens
+  on the three-step fixture, #69).
 - CI job `driver-compat` รัน `tests/test-flow-runner-live.sh` กับ canonical `cdp.py` ที่ pin tag
   `TEIBTO_DEV_STANDARDS_REF` (v0.82.0) ใน Chrome จริงทุก PR; ไม่มี secret `DEV_STANDARDS_DEPLOY_KEY` (read-only deploy key) = fail
   (fork PR = skip พร้อม warning) — drift ระหว่าง runner กับ driver ถูกจับก่อน merge (#66)

--- a/README.md
+++ b/README.md
@@ -94,7 +94,8 @@ scenario. Pin the target and send secrets through stdin rather than argv:
 $env:TGT_ID = '<page-target-id>'
 $env:TEIBTO_CDP_SCRIPT = 'D:\path\to\teibto-dev-standards\scripts\cdp.py'
 '{"username":"standard_user","password":"..."}' |
-  py scripts/flow-runner.py --flow examples/saucedemo.yaml --out runs/manual --vars-json -
+  py scripts/flow-runner.py --flow examples/saucedemo.yaml --out runs/manual --vars-json - `
+    --stdout summary
 ```
 
 The runner writes:
@@ -111,6 +112,10 @@ v2+, waits for the new main-frame document on navigation, polls bounded observab
 inputs, redacts secret variables, records every auto-answered dialog as evidence under a pinned
 `safe` dialog policy, and fails closed on command, wait, assertion, capture, console, or transport
 errors. An unasserted state-changing action is `UNVERIFIED`, never `PASS`.
+
+`--stdout summary` returns only the terminal result while the full event stream remains in
+`run-log.jsonl`. A step may set `perf_budget_ms` to fail when action + explicit outcome wait +
+assertion exceeds its budget; screenshot and session startup are excluded from that clock.
 
 For the exact YAML, wait, capture, and telemetry contracts, read
 [`references/flow-spec.md`](references/flow-spec.md).

--- a/SKILL.md
+++ b/SKILL.md
@@ -71,6 +71,8 @@ negotiates CDP JSONL protocol v2+, and owns one bounded `session --jsonl --input
 It replaces fixed input sleeps with bounded outcome checks, keeps application latency visible in
 action/wait timing, and emits separate action/wait/assert/capture timings. The runner fails closed on an old
 driver, an unsupported field, an assertion failure, or missing evidence.
+For agent-run flows, pass `--stdout summary`; the complete event stream remains in `run-log.jsonl`.
+Use step-level `perf_budget_ms` when action-to-observable-outcome time is an acceptance criterion.
 
 ## Outputs
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -56,12 +56,15 @@ flowchart LR
     runner -->|"JSONL v2 · one child per run<br/>event nav + phase timing"| session["cdp.py session<br/>bounded + pinned target<br/>input-settle=none"]
     session -->|"one WebSocket"| chrome["Chrome target"]
     runner --> artifacts["run-log.jsonl<br/>qa-report.md<br/>shots/"]
+    runner -->|"--stdout summary"| terminal["terminal verdict<br/>token-safe agent context"]
 ```
 
 Secrets enter the runner through stdin, not argv. Fixed input sleeps are removed only in this
 bounded runner contract; observable application latency is paid in explicit waits and reported
 separately from action/assert/capture driver time. An action, wait, screenshot, console check, or
 transport failure stops the scenario. Unasserted state-changing actions produce `UNVERIFIED`.
+Step-level `perf_budget_ms` compares action-through-observable-wait/assert wall time and excludes
+session startup and screenshot capture.
 
 ---
 
@@ -106,7 +109,7 @@ flowchart LR
 | Visual | UI changes | `steady` then `diff <base> <cur>` | diff within threshold |
 | Error surfacing | every key step | `console` | errors surface, not swallowed |
 | a11y | forms, new screens | `evalf` axe-core | count + top N within budget |
-| Perf | save/load paths | `eval` timing marks | under the scenario's ms budget |
+| Perf | save/load paths | step `perf_budget_ms`; ad-hoc timing marks | observable outcome under budget |
 | UX/UI lens | responsive / theme / keyboard work | `lens layout\|responsive\|theme\|focus\|netlog` | `verdict: PASS` — and `UNVERIFIED` is **not** a pass |
 
 Two things the table cannot show:

--- a/docs/CLAIMS-AUDIT.md
+++ b/docs/CLAIMS-AUDIT.md
@@ -9,6 +9,8 @@ history and `CHANGELOG.md`.
 - Browser QA release under review: `v2.1.0` (`2e65cec`).
 - Canonical driver: `teibto-dev-standards v0.82.0` (`df8121f`).
 - Performance runs: Windows host, Chrome `151.0.7922.140`, 2026-08-22.
+- Issue #69 revalidation: Windows host, Chrome `151.0.7922.174`, 2026-08-30; local driver file
+  blob `21bf0cb72adaee04633c21a1c5758cbbf7a4da96` from worktree commit `b745196`.
 - The tested `scripts/cdp.py` blob was `ce5b376df249cb479f902751bbbb4df7898889d0`, identical to
   the blob at canonical tag `v0.82.0`.
 - Driver internals are owned by canonical `tests/test-cdp.sh`; this repository keeps thin consumer
@@ -32,6 +34,8 @@ Status terms:
 | Fast input settle is scoped to direct runner input; `pick`/`lens` retain normal settle | verified | canonical session probe T19u/v |
 | Async fill/click outcomes remain bounded and observable | verified | delayed 150 ms input normalization and 300 ms trusted-click fixture in `tests/test-flow-runner-live.sh` |
 | Runner telemetry separates driver duration, runner wall time, attempts, and failing phase | verified | unit event assertions plus live `run-log.jsonl` parsing |
+| `--stdout summary` keeps the complete artifact but emits terminal output only | verified, measured | unit stream/artifact comparison; issue #69 o200k_base measurement below |
+| Step `perf_budget_ms` measures action through observable wait/assert and excludes capture/startup | verified | pass/exceedance unit tests with a delayed capture |
 | Missing/old driver fails as `DRIVER_INCOMPATIBLE` rather than using a silent fallback | verified | `tests/test_flow_runner.py` |
 | Success/failure screenshots follow scenario/step capture policy | verified | runner unit tests and live fixture |
 
@@ -44,6 +48,7 @@ The comparison measures summed live step time, excluding Chrome startup:
 | main baseline (`teibto-browser-qa@3ecafee`, driver `6656b9c`) | 5 isolated runs | 4,373.865 ms | fixed navigation/input settling |
 | protocol-v2 candidate | 20 fresh child sessions on one temporary Chrome target | 622.523 ms | 20/20 pass |
 | issue #54 revalidation | 20 fresh child sessions on one temporary Chrome target | 972.687 ms | 20/20 pass |
+| issue #69 current-host revalidation | 20 fresh child sessions on one temporary Chrome target | 618.904 ms | 20/20 pass |
 
 Measured improvement: **85.8%**. Candidate medians were startup 181.014 ms, open 30.552 ms, fill
 171.488 ms, click 396.767 ms, and total run 823.390 ms. The fixture intentionally waits 150/300 ms
@@ -53,6 +58,17 @@ The issue #54 revalidation medians were startup 208.707 ms, open 41.492 ms, fill
 739.543 ms, and total run 1,299.784 ms. The run verifies compatibility and records host variance; it
 does not replace the controlled release comparison or create a cross-machine latency gate.
 
+The issue #69 medians were startup 174.502 ms, open 24.486 ms, fill 215.526 ms, click 385.726 ms,
+and total run 826.889 ms. The 618.904 ms step flow is 85.8% below the 4,373.865 ms historical baseline;
+450 ms remains intentional fixture latency. This run used the exact local driver blob recorded above
+and does not change the repository's v0.82.0 compatibility pin (that bump is tracked separately).
+
+A controlled issue #69 regression check alternated 20 main/branch pairs after warm-up against the same
+Chrome target and the same pre-feature flow. Main versus branch medians were startup 309.575/310.072 ms
+(+0.2%), step flow 664.736/670.078 ms (+0.8%), and total 1,020.245/1,044.795 ms (+2.4%). This bounds
+the feature overhead on the measured host and explains why standalone runs at different times are not
+a valid before/after comparison.
+
 Absolute milliseconds are evidence for this host, not a cross-machine CI budget. The portable driver
 gate is ratio-based in canonical `tests/cdp-session-probe.py`. Reproduce with:
 
@@ -61,6 +77,14 @@ $env:TEIBTO_CDP_SCRIPT = '<teibto-dev-standards>/scripts/cdp.py'
 $env:LIVE_RUNS = '20'
 & 'C:\Program Files\Git\bin\bash.exe' tests/test-flow-runner-live.sh
 ```
+
+## Token evidence
+
+Measured with `tiktoken` 0.13.0, `o200k_base`, against the same three-step fake-driver flow on
+2026-08-30: full event stdout = 832 tokens; `--stdout summary` = 104 tokens, an **87.5% reduction**.
+Both modes retained the same complete 12-event start-to-done artifact sequence. The unit gate verifies
+the durable contract structurally (terminal result/error only on summary stdout, full artifact) rather
+than pinning a tokenizer-specific absolute count.
 
 ## Current browser/document claims
 
@@ -85,6 +109,9 @@ $env:LIVE_RUNS = '20'
 `retry_on`, `quarantine`, `a11y`, `perf_budget`, `mask_regions`, `diff_threshold`, and `ci_candidate`
 are **not executable fields** in v2.1.0. Their recipes/state live outside the flow until schema,
 execution behavior, reporting, and failure tests ship together.
+
+Issue #69 adds the executable integer field `perf_budget_ms` at step level. The older proposed
+scenario/object field `perf_budget` remains rejected; the two names are intentionally not aliases.
 
 This rule closed contradictory documentation found in `test-data.md`, `a11y-layer.md`,
 `perf-layer.md`, `visual-regression.md`, and `TEAM-PROCESS.md` during issue #54.

--- a/references/flow-spec.md
+++ b/references/flow-spec.md
@@ -10,7 +10,8 @@ test-design.md ตัดสิน *จะทดสอบอะไร*. ไฟล
 $env:TGT_ID = '<target id จาก cdp.py newtab หรือ tabs>'
 $env:TEIBTO_CDP_SCRIPT = 'D:\path\to\teibto-dev-standards\scripts\cdp.py'
 '{"username":"qa-user","password":"..."}' |
-  py scripts/flow-runner.py --flow examples/saucedemo.yaml --out runs/manual --vars-json -
+  py scripts/flow-runner.py --flow examples/saucedemo.yaml --out runs/manual --vars-json - `
+    --stdout summary
 ```
 
 - flow ทุกไฟล์ผ่าน `schemas/flow.schema.json` และ field ที่ไม่รู้จักทำให้หยุดทันที
@@ -24,6 +25,8 @@ $env:TEIBTO_CDP_SCRIPT = 'D:\path\to\teibto-dev-standards\scripts\cdp.py'
   policy เป็น `safe` เสมอ (ไม่ inherit `DIALOG` จาก shell) เว้นแต่สั่ง `--dialog accept|dismiss`
 - action ที่เปลี่ยน state แต่ไม่มี explicit assertion = verdict `UNVERIFIED`, ไม่ใช่ `PASS`
 - artifact อยู่ที่ `<out>/run-log.jsonl`, `<out>/qa-report.md`, `<out>/shots/`
+- `--stdout summary` ลด output เข้า agent context แต่ `run-log.jsonl` ยังเก็บ event เต็มเหมือนเดิม
+- `perf_budget_ms` ระดับ step วัด action → explicit wait → assertion; ไม่รวม startup/capture
 
 Local UI (ไม่จำเป็นต่อ CI):
 
@@ -64,6 +67,7 @@ scenarios:
         target: "<selector | @eN | {{var}} | url>"
         value: "<ค่า/ข้อความ (สำหรับ fill/select) — รองรับ {{var}}>"
         wait: networkidle | <ms> | "<selector>" | "fn:<js>"  # รอหลัง action
+        perf_budget_ms: 3000       # optional; เกินแล้ว PERF_BUDGET_EXCEEDED + FAIL
         capture: true|false        # override screenshot policy ของ scenario นี้
         assert:                  # พิสูจน์ผล (ตาม gotchas: อย่าเชื่อ ✓Done)
           url_contains: "/inventory.html"
@@ -95,6 +99,10 @@ timing ของตัวเอง และ `run_done` แยก startup/total.
 `DRIVER_INCOMPATIBLE`/`CDP_NOT_READY` ระบุ path ของ `cdp.py` ที่ runner resolve ได้จริง เพื่อให้รู้ว่า
 ต้องอัปเดตสำเนาไหนเมื่อเครื่องมี driver หลายชุด.
 
+เมื่อ step มี `perf_budget_ms`, `step_done.performance.outcome_ms` วัดตั้งแต่ก่อน action ถึงหลัง
+explicit wait/assert โดยไม่รวม screenshot; `run_done.performance_budgets` สรุป pass/evaluated/total.
+เกิน budget = typed failure `PERF_BUDGET_EXCEEDED` และเก็บ failure evidence ตาม capture policy.
+
 **Traceability (สำหรับทีม):** `ticket`/`requirement` + `acceptance` ทำให้ตอบได้ว่า *test นี้ยืนยัน
 req ไหน* และ *req นี้ครอบด้วย scenario ไหน*. 1 acceptance criterion → 1 scenario (map 1:1) →
 qa-report + user-guide อ้าง req เดียวกัน = ปิด loop req→test→doc. ดู playbook ทีมใน repo:
@@ -107,6 +115,9 @@ qa-report + user-guide อ้าง req เดียวกัน = ปิด loo
 Runner ปัจจุบันไม่รองรับ `fixtures`, `teardown`, `retry_on`, `quarantine`, `a11y`, `perf_budget`,
 `mask_regions`, `diff_threshold` หรือ `ci_candidate`; fail-closed schema ปฏิเสธทั้งหมดแทนการรับแล้ว
 ignore เงียบ ๆ.
+
+`perf_budget` แบบ object/scenario เดิมยังถูกปฏิเสธ; executable contract คือ integer
+`perf_budget_ms` ที่ step เท่านั้น.
 
 - เก็บ release/quarantine/coverage state ใน `qa/<feature>/coverage.yaml`.
 - ทำ setup/teardown เป็น orchestration แยก โดยใช้ scoped marker, identify-before-mutate และ dirty-state

--- a/references/perf-layer.md
+++ b/references/perf-layer.md
@@ -1,11 +1,42 @@
-# Performance layer — วัดเวลาโดยไม่ซ่อน application latency
+# Performance layer — วัด action ถึง observable outcome จริง
 
-เก็บเฉพาะตัวเลขที่ตอบ budget ของ scenario. ห้าม dump Navigation/Resource Timing ทั้งก้อน และห้าม
-เอา driver duration ไปอ้างเป็นเวลาที่ผู้ใช้รอ.
+Performance budget ที่ใช้ตัดสิน QA ต้องครอบเวลาที่ผู้ใช้รอผลธุรกิจ ไม่ใช่แค่เวลาที่ driver ส่ง click.
+คืนเฉพาะ milliseconds + budget verdict; ห้าม dump Navigation/Resource Timing ทั้งก้อน.
 
-## Navigation timing
+## Executable budget ใน flow
 
-หลัง `nav --until=load` อ่าน Navigation Timing API แบบย่อ:
+ใส่ `perf_budget_ms` ที่ step ซึ่งมี observable wait/assert ครบ:
+
+```yaml
+- intent: Save and wait for confirmation
+  action: click
+  target: "#btn_save"
+  wait: "fn:document.querySelector('#status')?.textContent==='saved'"
+  assert: {target: "#status", contains: "saved"}
+  perf_budget_ms: 3000
+```
+
+Clock เริ่มก่อน action และหยุดหลัง explicit wait + assertion:
+
+```text
+included: action + automatic fill verification + explicit wait + assertion
+excluded: session startup + screenshot capture + scenario console check
+```
+
+การแยกนี้สำคัญ: screenshot อาจช้าตามขนาดหน้า/เครื่อง แต่ไม่ใช่เวลาที่ผู้ใช้รอ Save. ถ้าเกิน budget
+runner คืน `PERF_BUDGET_EXCEEDED`, verdict `FAIL`, และเก็บ failure screenshot ตาม capture policy.
+
+หลักฐานอยู่สามที่:
+
+- `step_done.performance` = `outcome_ms`, `budget_ms`, `verdict`;
+- `run_done.performance_budgets` = `passed`, `evaluated`, `total`;
+- `qa-report.md` = บรรทัด `outcome: 842.123ms / budget 1500ms → PASS`.
+
+`step_done.duration_ms` ยังรวม capture จึงอาจมากกว่า `performance.outcome_ms`; อย่าใช้สองค่านี้แทนกัน.
+
+## Navigation timing สำหรับ diagnosis
+
+หลัง `nav --until=load` อ่าน Navigation Timing API แบบย่อได้:
 
 ```bash
 AB eval "(function(){var n=performance.getEntriesByType('navigation')[0]||{};
@@ -14,44 +45,50 @@ AB eval "(function(){var n=performance.getEntriesByType('navigation')[0]||{};
     load_ms:Math.round(n.loadEventEnd||0)});})()"
 ```
 
-`load_ms` เป็น browser lifecycle ไม่ใช่หลักฐานว่าข้อมูลของแอปพร้อม. ถ้าหน้ามี async component ให้
-รอและวัด observable outcome ที่ Acceptance Criteria ระบุ เช่น status text, row count หรือ enabled
-state.
+`load_ms` เป็น browser lifecycle ไม่ใช่หลักฐานว่าข้อมูล async พร้อม. Budget ใน flow จึงควรผูกกับ
+status text, row count, URL, enabled state หรือสัญญาณธุรกิจที่ Acceptance Criteria ระบุ.
 
-## Action-to-outcome timing
-
-สำหรับ flow YAML ใช้ `run-log.jsonl` เป็นแหล่งหลัก:
-
-- `action.driver_ms` = เวลาที่ driver ใช้ส่ง trusted input;
-- `wait.wall_ms` = เวลาที่ application ใช้จน observable condition เป็นจริง;
-- `step.total_ms` = runner wall time รวม assertion/capture ที่เปิดใช้;
-- `attempts` และ `failing_phase` ใช้แยก transport retry จาก application failure.
-
-Runner protocol v2 ตัดเฉพาะ fixed input settle และย้ายเวลาที่ต้องรอจริงไปอยู่ใน bounded outcome
-wait. อย่าสรุปว่า action เร็วขึ้นจาก `driver_ms` อย่างเดียว.
-
-งาน ad-hoc ที่อยู่ใน document เดิมใช้ mark ก่อน trusted action แล้ววัดหลัง bounded wait:
+งาน ad-hoc ที่ไม่ navigate ใช้ performance mark ได้ แต่ mark จะหายเมื่อเปลี่ยน document:
 
 ```bash
 AB eval "performance.clearMarks('qa_start');performance.mark('qa_start');'marked'"
 AB click "#save"
 AB wait "document.querySelector('#status')?.textContent==='saved'" 20 0.05
 AB eval "performance.mark('qa_end');performance.measure('qa_action','qa_start','qa_end');
-  JSON.stringify({action_to_outcome_ms:Math.round(performance.getEntriesByName('qa_action').at(-1).duration)})"
+  JSON.stringify({outcome_ms:Math.round(performance.getEntriesByName('qa_action').at(-1).duration)})"
 ```
 
-ถ้า action navigate ไป document ใหม่ performance mark เดิมจะหาย ให้ใช้ runner phase telemetry หรือ
-Navigation Timing ของ document ใหม่แทน.
+ถ้า action navigate ให้ใช้ `perf_budget_ms` ของ runner; clock ฝั่ง runner ไม่ตายพร้อม document.
 
-## Budget และรายงาน
+## Fast path สำหรับ NetSuite
 
-`perf_budget` ยังไม่ใช่ executable `flow.yaml` field. เก็บ budget ใน Acceptance Criteria หรือ
-coverage manifest แล้วเปรียบเทียบกับค่าที่วัดได้ในรายงาน เช่น:
+สำหรับ Suitelet/non-record page ให้ลด overhead โดยยังเก็บหลักฐานที่เชื่อได้:
 
-```text
-checkout confirmation: 842 ms / budget 1,500 ms -> PASS
-source: step SC-CHECKOUT-01 wait.wall_ms
+1. ใช้ persistent `--user-data-dir` เพื่อเก็บ login/trusted-device token แต่แยกหนึ่ง profile + port
+   ต่อ job; ห้ามรันขนานด้วย profile เดียวเพราะ cookie/session ชนกัน.
+2. รวม scenarios ที่เกี่ยวข้องไว้ใน flow เดียว เพื่อ reuse `cdp.py session --jsonl` process/WebSocket
+   เดียว; อย่าเรียก driver process ใหม่ทุก step.
+3. ใช้ page-specific observable `wait: "fn:..."`; หลีกเลี่ยง fixed sleep และชื่อ compatibility
+   `networkidle` เมื่อผลที่ต้องการเป็น AJAX/Oracle JET state.
+4. ใช้ `doc: false` ใน performance/adversarial pass และไม่ต้องใส่ `capture:false`: step ที่ผ่านจะไม่ถ่าย
+   แต่ failure ยังได้ screenshot อัตโนมัติ.
+5. รัน agent ด้วย `--stdout summary`; JSONL เต็มยังอยู่ใน artifact โดยไม่ไหลเข้า context.
+6. ใช้ selector/get/count แบบแคบ; ห้าม whole-page HTML หรือ a11y dump.
+
+ตัวอย่าง:
+
+```powershell
+'{"base_url":"https://..."}' |
+  py scripts/flow-runner.py --flow qa/suitelet/flow.yaml --out runs/suitelet-perf `
+    --vars-json - --target-id $env:TGT_ID --stdout summary
 ```
 
-รายงาน environment, จำนวนรอบ และ median/p95 เมื่อใช้ตัวเลขตัดสิน release. รอบเดียวเหมาะกับ diagnosis
-แต่ไม่พอสำหรับ claim เรื่อง performance regression.
+NetSuite record-form QA ยังเป็นขอบเขตของ `netsuite-ui-qa-testing`; ใช้หลัก profile isolation,
+observable outcome และ token-safe output เดียวกัน แต่ใช้ pipeline ของ skill นั้น.
+
+## ตีความตัวเลข
+
+- รอบเดียวเหมาะกับ diagnosis และ budget ต่อ run; claim regression ควรรันซ้ำแล้วรายงาน median/p95.
+- รายงาน Chrome, driver revision, จำนวนรอบ และ fixture/application delay ที่ตั้งใจไว้.
+- เปรียบเทียบ host เดียวกันเมื่อใช้ absolute milliseconds; CI ข้ามเครื่องควรใช้ budget ที่เผื่อ variance.
+- ห้ามอ้าง `driver_ms` อย่างเดียวว่า Save เร็ว เพราะ application latency อยู่ใน wait wall time.

--- a/schemas/flow.schema.json
+++ b/schemas/flow.schema.json
@@ -75,6 +75,7 @@
         "target": {"type": "string"},
         "value": {"type": ["string", "number", "boolean", "null"]},
         "wait": {"anyOf": [{"const": "networkidle"}, {"type": "integer", "minimum": 0, "maximum": 60000}, {"type": "string", "minLength": 1}]},
+        "perf_budget_ms": {"type": "integer", "minimum": 1, "maximum": 600000},
         "assert": {"$ref": "#/$defs/assertion"},
         "capture": {"type": "boolean"}
       },

--- a/scripts/flow-runner.py
+++ b/scripts/flow-runner.py
@@ -7,7 +7,8 @@ Examples:
   '{"password":"..."}' | py scripts/flow-runner.py --flow examples/saucedemo.yaml `
       --out runs/manual --vars-json -
 
-JSON events are written to stdout and runs/<id>/run-log.jsonl. Secrets are never
+Complete JSON events are written to runs/<id>/run-log.jsonl. Stdout defaults to the
+same event stream; use --stdout summary for token-safe agent runs. Secrets are never
 placed in argv or artifacts. Exit 0=PASS, 1=FAIL/UNVERIFIED, 2=setup/input error.
 """
 from __future__ import annotations
@@ -45,6 +46,8 @@ SESSION_PROTOCOL = "teibto-cdp-jsonl"
 MIN_SESSION_VERSION = 2
 INPUT_SETTLE_POLICY = "none"
 DIALOG_POLICIES = ("safe", "accept", "dismiss")
+STDOUT_MODES = ("events", "summary")
+SUMMARY_EVENT_TYPES = {"fatal", "run_done"}
 # cdp.py prints every auto-answered dialog to stderr as "[dialog] <kind>: <message> -> <answer>".
 DIALOG_LINE = re.compile(r"^\[dialog\] (?P<kind>[^:]+): (?P<message>.*) -> (?P<answer>\S+)$")
 
@@ -146,17 +149,20 @@ def resolve_cdp_script(explicit: str | None) -> Path:
 
 
 class EventSink:
-    def __init__(self, output: TextIO, path: Path | None, secrets: set[str], variables: dict[str, Any]):
+    def __init__(self, output: TextIO, path: Path | None, secrets: set[str], variables: dict[str, Any],
+                 *, stdout_mode: str = "events"):
         self.output = output
         self.file = path.open("w", encoding="utf-8") if path else None
         self.secrets = secrets
         self.variables = variables
+        self.stdout_mode = stdout_mode
 
     def emit(self, payload: dict[str, Any]) -> None:
         safe = redact(payload, self.secrets, self.variables)
         line = json.dumps(safe, ensure_ascii=False, separators=(",", ":"))
-        self.output.write(line + "\n")
-        self.output.flush()
+        if self.stdout_mode == "events" or safe.get("type") in SUMMARY_EVENT_TYPES:
+            self.output.write(line + "\n")
+            self.output.flush()
         if self.file:
             self.file.write(line + "\n")
             self.file.flush()
@@ -405,6 +411,10 @@ class StepTimings:
             payload["failing_phase"] = self.failing_phase
         return payload
 
+    def elapsed_ms(self) -> float:
+        return round((time.perf_counter() - self.started) * 1000, 3)
+
+
 def js_selector(selector: str) -> str:
     return json.dumps(selector, ensure_ascii=False)
 
@@ -539,6 +549,9 @@ def run_flow(flow: dict[str, Any], path: Path, output_dir: Path, variables: dict
     assertions = sum(1 for scenario in flow["scenarios"] for step in scenario["steps"]
                      if step.get("assert"))
     passed = failures = unverified = dialogs = 0
+    perf_total = sum(1 for scenario in flow["scenarios"] for step in scenario["steps"]
+                     if step.get("perf_budget_ms") is not None)
+    perf_evaluated = perf_passed = 0
     session: CDPSession | None = None
 
     def flush_dialogs(scenario_id: str, index: int | None, global_index: int | None) -> None:
@@ -580,6 +593,7 @@ def run_flow(flow: dict[str, Any], path: Path, output_dir: Path, variables: dict
                 sink.emit({"type": "step", "scenario": scenario["id"], "index": index,
                            "global_index": global_index, "intent": intent, "status": "running"})
                 timings = StepTimings()
+                performance: dict[str, Any] | None = None
                 try:
                     context = perform_action(session, raw_step, variables, timings)
                     perform_wait(session, raw_step.get("wait"), variables, context, timings)
@@ -595,6 +609,24 @@ def run_flow(flow: dict[str, Any], path: Path, output_dir: Path, variables: dict
                     elif raw_step["action"] in MUTATING_ACTIONS:
                         unverified += 1
                         status, detail = "unverified", "state-changing step has no explicit assertion"
+                    budget_ms = raw_step.get("perf_budget_ms")
+                    if budget_ms is not None:
+                        outcome_ms = timings.elapsed_ms()
+                        perf_evaluated += 1
+                        within_budget = outcome_ms <= budget_ms
+                        performance = {
+                            "outcome_ms": outcome_ms,
+                            "budget_ms": budget_ms,
+                            "verdict": "PASS" if within_budget else "FAIL",
+                        }
+                        if not within_budget:
+                            timings.fail("perf_budget")
+                            raise RunnerError(
+                                "PERF_BUDGET_EXCEEDED",
+                                f"observable outcome {outcome_ms:.3f}ms exceeds budget {budget_ms}ms",
+                                detail=performance,
+                            )
+                        perf_passed += 1
                     shot = None
                     capture_success = (raw_step["capture"] if "capture" in raw_step
                                        else bool(scenario.get("doc", False)))
@@ -604,11 +636,17 @@ def run_flow(flow: dict[str, Any], path: Path, output_dir: Path, variables: dict
                         shot = str(shot_path)
                     marker = "✅" if status == "pass" else ("⚠️" if status == "unverified" else "▸")
                     report.append(f"- {marker} {intent}" + (f" — {detail}" if detail else ""))
+                    if performance:
+                        report.append(
+                            f"  - ⏱ outcome: {performance['outcome_ms']:.3f}ms / "
+                            f"budget {performance['budget_ms']}ms → {performance['verdict']}"
+                        )
                     flush_dialogs(scenario["id"], index, global_index)
                     timing_payload = timings.payload()
                     sink.emit({"type": "step_done", "scenario": scenario["id"], "index": index,
                                "global_index": global_index, "intent": intent, "status": status,
                                "detail": detail, "shot": shot,
+                               **({"performance": performance} if performance else {}),
                                "duration_ms": timing_payload["total_ms"],
                                "timings": timing_payload})
                 except RunnerError as exc:
@@ -624,12 +662,18 @@ def run_flow(flow: dict[str, Any], path: Path, output_dir: Path, variables: dict
                         except RunnerError as capture_exc:
                             evidence_error = {"code": capture_exc.code, "message": str(capture_exc)}
                     report.append(f"- ❌ {intent} — {exc.code}: {exc}")
+                    if performance:
+                        report.append(
+                            f"  - ⏱ outcome: {performance['outcome_ms']:.3f}ms / "
+                            f"budget {performance['budget_ms']}ms → {performance['verdict']}"
+                        )
                     flush_dialogs(scenario["id"], index, global_index)
                     timing_payload = timings.payload()
                     sink.emit({"type": "step_done", "scenario": scenario["id"], "index": index,
                                "global_index": global_index, "intent": intent, "status": "fail",
                                "error": {"code": exc.code, "message": str(exc)},
                                "shot": shot,
+                               **({"performance": performance} if performance else {}),
                                **({"evidence_error": evidence_error} if evidence_error else {}),
                                "duration_ms": timing_payload["total_ms"],
                                "timings": timing_payload})
@@ -697,11 +741,16 @@ def run_flow(flow: dict[str, Any], path: Path, output_dir: Path, variables: dict
     summary = [f"**Verdict:** {verdict}", f"**Assertions:** {passed}/{assertions} passed",
                f"**Unverified state changes:** {unverified}",
                f"**Auto-answered dialogs:** {dialogs} (policy: {dialog})", ""]
+    if perf_total:
+        summary.insert(3, f"**Performance budgets:** {perf_passed}/{perf_total} passed "
+                          f"({perf_evaluated} evaluated)")
     report[4:4] = summary
     safe_report = redact("\n".join(report), sink.secrets, variables, truncate=False)
     report_path.write_text(str(safe_report), encoding="utf-8")
     sink.emit({"type": "run_done", "passed": passed, "total": assertions,
                "failures": failures, "unverified": unverified, "dialogs": dialogs,
+               "performance_budgets": {"passed": perf_passed, "evaluated": perf_evaluated,
+                                       "total": perf_total},
                "verdict": verdict,
                "duration_ms": round((time.perf_counter() - run_started) * 1000, 3),
                "startup_ms": startup_ms,
@@ -732,6 +781,8 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--cdp-script")
     parser.add_argument("--dialog", choices=DIALOG_POLICIES, default="safe",
                         help="dialog policy handed to cdp.py (default: safe; never inherited from env)")
+    parser.add_argument("--stdout", choices=STDOUT_MODES, default="events",
+                        help="events (default) or terminal summary only; run-log.jsonl is always complete")
     parser.add_argument("--meta", action="store_true")
     parser.add_argument("--full", action="store_true")
     args = parser.parse_args(argv)
@@ -758,7 +809,8 @@ def main(argv: list[str] | None = None) -> int:
             raise RunnerError("OUTPUT_EXISTS", f"output directory มีอยู่แล้ว: {output_dir}")
         output_dir.mkdir(parents=True)
         log_path = output_dir / "run-log.jsonl"
-        sink = EventSink(sys.stdout, log_path, secret_names(flow), variables)
+        sink = EventSink(sys.stdout, log_path, secret_names(flow), variables,
+                         stdout_mode=args.stdout)
         return run_flow(flow, path, output_dir, variables, cdp_script,
                         args.target_id or "", args.cdp_port, sink, dialog=args.dialog)
     except RunnerError as exc:

--- a/tests/fixtures/fake_cdp.py
+++ b/tests/fixtures/fake_cdp.py
@@ -4,6 +4,7 @@ import json
 import os
 import pathlib
 import sys
+import time
 
 target = next((arg.split("=", 1)[1] for arg in sys.argv if arg.startswith("--target-id=")), "")
 input_settle = next((arg.split("=", 1)[1] for arg in sys.argv
@@ -75,6 +76,7 @@ for line in sys.stdin:
     elif command == "console":
         data = []
     elif command == "shot":
+        time.sleep(float(os.environ.get("FAKE_CDP_SHOT_DELAY_MS", "0")) / 1000)
         pathlib.Path(args[0]).write_bytes(b"PNG")
         data = args[0]
     else:

--- a/tests/fixtures/live-flow.yaml
+++ b/tests/fixtures/live-flow.yaml
@@ -18,4 +18,5 @@ scenarios:
         target: "#save"
         wait: "fn:document.querySelector('#status').textContent.startsWith('saved')"
         assert: {target: "#status", contains: "saved"}
+        perf_budget_ms: 10000
         capture: true

--- a/tests/test-flow-runner-live.sh
+++ b/tests/test-flow-runner-live.sh
@@ -65,14 +65,16 @@ LIVE_RUNS="${LIVE_RUNS:-1}"
 [[ "${LIVE_RUNS}" =~ ^[0-9]+$ ]] && [ "${LIVE_RUNS}" -ge 1 ] && [ "${LIVE_RUNS}" -le 50 ] \
   || { echo "FAIL: LIVE_RUNS must be an integer in 1..50"; exit 2; }
 for run in $(seq 1 "${LIVE_RUNS}"); do
-  # Print the runner log on failure: cleanup removes ${WORK}, so a silent exit would hide the cause
-  # (for example DRIVER_INCOMPATIBLE from a stale cdp.py).
+  # Print terminal output and the full artifact on failure: cleanup removes ${WORK}, so a silent
+  # exit would hide the cause (for example DRIVER_INCOMPATIBLE from a stale cdp.py).
   printf '%s' "${VARS}" | "${PY}" "${ROOT}/scripts/flow-runner.py" \
     --flow "${ROOT}/tests/fixtures/live-flow.yaml" --out "${WORK}/out-${run}" --vars-json - \
-    --target-id "${TARGET_ID}" --cdp-script "${CDP}" >"${WORK}/runner-${run}.jsonl" || {
+    --target-id "${TARGET_ID}" --cdp-script "${CDP}" --stdout summary \
+    >"${WORK}/runner-${run}.jsonl" || {
     code=$?
     echo "FAIL: runner exit ${code} on run ${run} (driver: ${CDP})"
     cat "${WORK}/runner-${run}.jsonl"
+    [ ! -f "${WORK}/out-${run}/run-log.jsonl" ] || cat "${WORK}/out-${run}/run-log.jsonl"
     exit 1
   }
 done
@@ -101,9 +103,15 @@ for run in range(1, count + 1):
     assert fill["action"]["wall_ms"] + fill["wait"]["wall_ms"] >= 140, fill
     assert click["action"]["wall_ms"] + click["wait"]["wall_ms"] >= 280, click
     assert "assert" in click and "capture" in click, click
+    assert steps[2]["performance"]["verdict"] == "PASS", steps[2]
+    assert 280 <= steps[2]["performance"]["outcome_ms"] <= 10000, steps[2]
     assert next(item for item in events if item["type"] == "errors").get("timing"), events
     done = next(item for item in events if item["type"] == "run_done")
     assert done["verdict"] == "PASS", done
+    assert done["performance_budgets"] == {"passed": 1, "evaluated": 1, "total": 1}, done
+    terminal = [json.loads(line) for line in
+                (work / f"runner-{run}.jsonl").read_text(encoding="utf-8").splitlines()]
+    assert [item["type"] for item in terminal] == ["run_done"], terminal
     rows.append({"startup_ms": done["startup_ms"], "open_ms": steps[0]["duration_ms"],
                  "fill_ms": steps[1]["duration_ms"], "click_ms": steps[2]["duration_ms"],
                  "step_total_ms": sum(item["duration_ms"] for item in steps),
@@ -114,4 +122,4 @@ print(json.dumps({"runs": count, "failures": 0,
 PY
 if grep -R -q 's3cret-Ada' "${WORK}"/out-*/run-log.jsonl; then exit 1; fi
 if grep -R -q 's3cret-Ada' "${WORK}"/out-*/qa-report.md; then exit 1; fi
-echo "PASS: ${LIVE_RUNS} real-Chrome run(s) used protocol v2, event-bound nav, fast native input, async waits, redaction, telemetry, and artifacts"
+echo "PASS: ${LIVE_RUNS} real-Chrome run(s) used protocol v2, event-bound nav, fast native input, async waits, performance budgets, summary stdout, redaction, telemetry, and artifacts"

--- a/tests/test_flow_runner.py
+++ b/tests/test_flow_runner.py
@@ -89,6 +89,93 @@ class FlowRunnerTests(unittest.TestCase):
         self.assertIn("assert", steps[2]["timings"]["phases"])
         self.assertIn("timing", next(item for item in payloads if item["type"] == "errors"))
 
+    def test_summary_stdout_preserves_complete_run_log(self):
+        process, out, _ = self.run_flow("""
+            story: token-safe
+            title: Token-safe stdout
+            scenarios:
+              - id: smoke
+                steps:
+                  - {action: open, target: "https://example.test", capture: false}
+        """, extra_args=["--stdout", "summary"])
+        self.assertEqual(0, process.returncode, process.stdout + process.stderr)
+        stdout_events = [json.loads(line) for line in process.stdout.splitlines()]
+        artifact_events = [json.loads(line) for line in
+                           (out / "run-log.jsonl").read_text(encoding="utf-8").splitlines()]
+        self.assertEqual(["run_done"], [item["type"] for item in stdout_events])
+        self.assertGreater(len(artifact_events), len(stdout_events))
+        self.assertEqual("run_start", artifact_events[0]["type"])
+        self.assertEqual("run_done", artifact_events[-1]["type"])
+
+    def test_summary_stdout_keeps_fatal_error_visible(self):
+        process, _, _ = self.run_flow("""
+            story: token-safe-fatal
+            title: Token-safe fatal output
+            scenarios:
+              - id: smoke
+                steps:
+                  - {action: open, target: "https://example.test", capture: false}
+        """, env_overrides={"FAKE_CDP_VERSION": "1"}, extra_args=["--stdout", "summary"])
+        self.assertEqual(1, process.returncode)
+        stdout_events = [json.loads(line) for line in process.stdout.splitlines()]
+        self.assertEqual(["fatal", "run_done"], [item["type"] for item in stdout_events])
+        self.assertEqual("DRIVER_INCOMPATIBLE", stdout_events[0]["error"]["code"])
+
+    def test_perf_budget_excludes_capture_and_reports_pass(self):
+        process, out, _ = self.run_flow("""
+            story: perf-pass
+            title: Performance pass
+            scenarios:
+              - id: load
+                doc: true
+                steps:
+                  - action: open
+                    target: "https://example.test"
+                    wait: 30
+                    perf_budget_ms: 500
+        """, env_overrides={"FAKE_CDP_SHOT_DELAY_MS": "800"})
+        self.assertEqual(0, process.returncode, process.stdout + process.stderr)
+        payloads = [json.loads(line) for line in
+                    (out / "run-log.jsonl").read_text(encoding="utf-8").splitlines()]
+        step = next(item for item in payloads if item["type"] == "step_done")
+        self.assertEqual("PASS", step["performance"]["verdict"])
+        self.assertLessEqual(step["performance"]["outcome_ms"], 500)
+        self.assertGreaterEqual(step["duration_ms"] - step["performance"]["outcome_ms"], 700)
+        done = next(item for item in payloads if item["type"] == "run_done")
+        self.assertEqual({"passed": 1, "evaluated": 1, "total": 1},
+                         done["performance_budgets"])
+        report = (out / "qa-report.md").read_text(encoding="utf-8")
+        self.assertIn("**Performance budgets:** 1/1 passed (1 evaluated)", report)
+        self.assertIn("budget 500ms → PASS", report)
+
+    def test_perf_budget_exceedance_fails_closed_with_evidence(self):
+        process, out, _ = self.run_flow("""
+            story: perf-fail
+            title: Performance failure
+            scenarios:
+              - id: save
+                steps:
+                  - action: open
+                    target: "https://example.test"
+                    wait: 50
+                    perf_budget_ms: 5
+        """)
+        self.assertEqual(1, process.returncode)
+        payloads = [json.loads(line) for line in
+                    (out / "run-log.jsonl").read_text(encoding="utf-8").splitlines()]
+        step = next(item for item in payloads if item["type"] == "step_done")
+        self.assertEqual("PERF_BUDGET_EXCEEDED", step["error"]["code"])
+        self.assertEqual("FAIL", step["performance"]["verdict"])
+        self.assertGreater(step["performance"]["outcome_ms"], 5)
+        self.assertEqual("perf_budget", step["timings"]["failing_phase"])
+        self.assertTrue(Path(step["shot"]).is_file())
+        done = next(item for item in payloads if item["type"] == "run_done")
+        self.assertEqual({"passed": 0, "evaluated": 1, "total": 1},
+                         done["performance_budgets"])
+        report = (out / "qa-report.md").read_text(encoding="utf-8")
+        self.assertIn("PERF_BUDGET_EXCEEDED", report)
+        self.assertIn("budget 5ms → FAIL", report)
+
     def test_unasserted_click_is_unverified(self):
         process, out, _ = self.run_flow("""
             story: unverified
@@ -112,6 +199,21 @@ class FlowRunnerTests(unittest.TestCase):
               - id: smoke
                 steps:
                   - {action: click, target: "#x", silentFallback: true}
+        """), encoding="utf-8")
+        with self.assertRaises(runner.RunnerError) as caught:
+            runner.load_flow(path)
+        self.assertEqual("INVALID_FLOW", caught.exception.code)
+
+    def test_schema_rejects_nonpositive_perf_budget(self):
+        runner = load_runner()
+        path = self.workspace() / "bad-perf.yaml"
+        path.write_text(textwrap.dedent("""
+            story: bad-perf
+            title: Bad performance budget
+            scenarios:
+              - id: smoke
+                steps:
+                  - {action: open, target: "https://example.test", perf_budget_ms: 0}
         """), encoding="utf-8")
         with self.assertRaises(runner.RunnerError) as caught:
             runner.load_flow(path)


### PR DESCRIPTION
## Summary

- add `--stdout summary` for token-safe agent runs while keeping the complete JSONL artifact
- add executable step-level `perf_budget_ms` from action through observable wait/assert, excluding startup and capture
- fail budget exceedance with `PERF_BUDGET_EXCEEDED`, telemetry, report evidence, and failure screenshot
- document the fast NetSuite profile/session/wait/capture pattern and record measured provenance

## Measured evidence

- stdout A/B, same 3-step flow: 832 → 104 o200k_base tokens (**87.5% reduction**)
- live branch gate: 20/20 pass with performance budget + summary stdout
- controlled runtime A/B, 20 alternating pairs on one Chrome target: step median 664.736 ms main vs 670.078 ms branch (**+0.8%**); startup +0.2%
- historical current transport remains 85.8% faster than the fixed-settle baseline; 450 ms fixture app latency remains observable

## Verification

- `python -m unittest discover -s tests -v` — 26 passed
- `python scripts/validate-skill.py` — pass
- `python scripts/build-skill.py` — pass (27 entries)
- `node --check app/server.js` — pass
- `tests/test-flow-runner-live.sh` with `LIVE_RUNS=20` — 20/20 pass
- `self-test/smoke-test.sh` — 41 passed, 0 failed
- `git diff --check` — pass

Driver protocol-v3/pin work remains separate in #68.

Closes #69