### PR TITLE
chore(driver): require protocol v3 and pin v0.83.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,10 @@ permissions:
   contents: read
 
 env:
-  # Canonical driver generation this runner is verified against (JSONL protocol v2+).
+  # Canonical driver generation this runner is verified against (JSONL protocol v3+).
   # Bump deliberately together with README/CONTRIBUTING; driver-compat runs the live test
   # against exactly this tag of Teibto/teibto-dev-standards.
-  TEIBTO_DEV_STANDARDS_REF: v0.82.0
+  TEIBTO_DEV_STANDARDS_REF: v0.83.0
 
 jobs:
   quality-gate:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,16 @@
   outcomes and records budget evidence in JSONL/report artifacts (measured 87.5% fewer stdout tokens
   on the three-step fixture, #69).
 - CI job `driver-compat` รัน `tests/test-flow-runner-live.sh` กับ canonical `cdp.py` ที่ pin tag
-  `TEIBTO_DEV_STANDARDS_REF` (v0.82.0) ใน Chrome จริงทุก PR; ไม่มี secret `DEV_STANDARDS_DEPLOY_KEY` (read-only deploy key) = fail
+  `TEIBTO_DEV_STANDARDS_REF` (v0.83.0) ใน Chrome จริงทุก PR; ไม่มี secret `DEV_STANDARDS_DEPLOY_KEY` (read-only deploy key) = fail
   (fork PR = skip พร้อม warning) — drift ระหว่าง runner กับ driver ถูกจับก่อน merge (#66)
 - `session_ready.cdp_script` และข้อความ `DRIVER_INCOMPATIBLE`/`CDP_NOT_READY`/`TARGET_MISMATCH`
   ระบุ path ของ `cdp.py` ที่ runner resolve ได้ เพื่อชี้สำเนาที่ต้องอัปเดตเมื่อเครื่องมี driver หลายชุด (#58)
+
+### Changed
+
+- Runner และ `driver-compat` ยก minimum contract เป็น canonical `cdp.py` v0.83.0 / JSONL protocol v3;
+  structured `result.dialogs` เป็น authority ที่ผูก dialog กับ step โดยตรง, stderr ใช้ diagnosis
+  และ malformed payload fail closed แทน run-level ledger/race (#68).
 
 ### Fixed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ How to change this skill without breaking the discipline it is built on. New her
 ## Prerequisites
 
 - Chrome + `py -m pip install websocket-client pillow numpy` — needed to run `self-test/smoke-test.sh`.
-  Use canonical `cdp.py` protocol v2+ (v0.82.0 or newer); override the standard team path with
+  Use canonical `cdp.py` protocol v3+ (v0.83.0 or newer); override the standard team path with
   `NS_CDP` for smoke tests or `TEIBTO_CDP_SCRIPT` for the flow runner.
 - Python 3.10+ with PyYAML/jsonschema: `pip install -r requirements.txt` — for the `scripts/`.
 - Node.js 20+ only when changing the optional local UI.
@@ -71,8 +71,9 @@ Re-run after any Chrome or `cdp.py` version bump — this is the drift detector.
 ### Driver pin and the `driver-compat` CI job
 
 The runner is verified against one canonical driver generation: `TEIBTO_DEV_STANDARDS_REF` in
-`.github/workflows/ci.yml` (currently `v0.82.0`, the first `teibto-dev-standards` tag with JSONL
-protocol v2). CI job `driver-compat` clones that exact tag and runs `tests/test-flow-runner-live.sh`
+`.github/workflows/ci.yml` (currently `v0.83.0`, the first `teibto-dev-standards` tag with JSONL
+protocol v3 and structured per-command dialogs). CI job `driver-compat` clones that exact tag and runs
+`tests/test-flow-runner-live.sh`
 in real Chrome on every pull request, so driver drift fails before merge instead of on a developer
 machine. `teibto-dev-standards` is private: the job needs the repository secret
 `DEV_STANDARDS_DEPLOY_KEY` — the private half of a **read-only deploy key** registered on that repository

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ one live flow into an evidence-backed verdict and, when needed, a user guide or 
 - Short, bounded assertions and filtered accessibility output instead of whole-page dumps.
 - Console, screenshot, visual-diff, responsive, theme, keyboard-focus, network, a11y, and performance
   evidence as opt-in layers.
-- A strict YAML runner that pins one target and uses one bounded CDP JSONL protocol-v2 session per run.
+- A strict YAML runner that pins one target and uses one bounded CDP JSONL protocol-v3 session per run.
 - Per-phase telemetry that separates driver work from application waits.
 - HTML/PDF templates for user guides and bug reports generated from the same evidence run.
 
@@ -33,7 +33,7 @@ plans, evidence packs, and release-readiness review use `teibto-qa-review`.
 ```mermaid
 flowchart LR
     spec["Flow YAML or ad-hoc steps"] --> runner["flow-runner.py"]
-    runner -->|"JSONL v2<br/>bounded session"| cdp["canonical cdp.py"]
+    runner -->|"JSONL v3<br/>bounded session"| cdp["canonical cdp.py"]
     cdp --> chrome["Pinned Chrome target"]
     chrome --> evidence["short results + screenshots"]
     evidence --> report["QA report"]
@@ -53,8 +53,8 @@ py -m pip install -r requirements.txt
 py -m pip install websocket-client pillow numpy
 ```
 
-The flow runner requires canonical `cdp.py` JSONL protocol v2 or newer, first released in
-[`teibto-dev-standards v0.82.0`](https://github.com/Teibto/teibto-dev-standards/releases/tag/v0.82.0).
+The flow runner requires canonical `cdp.py` JSONL protocol v3 or newer, first released in
+[`teibto-dev-standards v0.83.0`](https://github.com/Teibto/teibto-dev-standards/releases/tag/v0.83.0).
 Pass its path with `--cdp-script` or `TEIBTO_CDP_SCRIPT`. The runner also checks the standard team
 installation path automatically. CI verifies every change against that pinned tag in real Chrome
 (`driver-compat` job; see [`CONTRIBUTING.md`](CONTRIBUTING.md)).
@@ -108,7 +108,8 @@ runs/manual/
 ```
 
 It validates the schema before opening the driver, refuses to guess a shared tab, negotiates protocol
-v2+, waits for the new main-frame document on navigation, polls bounded observable outcomes after fast
+v3+, attributes structured dialog evidence to the command/step that caused it, waits for the new
+main-frame document on navigation, and polls bounded observable outcomes after fast
 inputs, redacts secret variables, records every auto-answered dialog as evidence under a pinned
 `safe` dialog policy, and fails closed on command, wait, assertion, capture, console, or transport
 errors. An unasserted state-changing action is `UNVERIFIED`, never `PASS`.

--- a/SKILL.md
+++ b/SKILL.md
@@ -67,7 +67,7 @@ Use `a11y "<visible name>"` to obtain a semantic `@ref` when a stable selector i
 that it had no errors. Use `lens netlog` only inside a `run` that enabled `netlog on`.
 
 For repeatable flows, `scripts/flow-runner.py` validates the YAML schema, requires a pinned target,
-negotiates CDP JSONL protocol v2+, and owns one bounded `session --jsonl --input-settle=none` per run.
+negotiates CDP JSONL protocol v3+, and owns one bounded `session --jsonl --input-settle=none` per run.
 It replaces fixed input sleeps with bounded outcome checks, keeps application latency visible in
 action/wait timing, and emits separate action/wait/assert/capture timings. The runner fails closed on an old
 driver, an unsupported field, an assertion failure, or missing evidence.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -53,7 +53,7 @@ flowchart LR
     yaml["flow YAML"] --> schema["flow.schema.json<br/>fail closed"]
     ui["local UI<br/>127.0.0.1"] --> runner
     schema --> runner["flow-runner.py<br/>events + report + shots"]
-    runner -->|"JSONL v2 · one child per run<br/>event nav + phase timing"| session["cdp.py session<br/>bounded + pinned target<br/>input-settle=none"]
+    runner -->|"JSONL v3 · one child per run<br/>event nav + phase timing + dialogs"| session["cdp.py session<br/>bounded + pinned target<br/>input-settle=none"]
     session -->|"one WebSocket"| chrome["Chrome target"]
     runner --> artifacts["run-log.jsonl<br/>qa-report.md<br/>shots/"]
     runner -->|"--stdout summary"| terminal["terminal verdict<br/>token-safe agent context"]

--- a/docs/CLAIMS-AUDIT.md
+++ b/docs/CLAIMS-AUDIT.md
@@ -6,13 +6,13 @@ history and `CHANGELOG.md`.
 
 ## Evidence boundary
 
-- Browser QA release under review: `v2.1.0` (`2e65cec`).
-- Canonical driver: `teibto-dev-standards v0.82.0` (`df8121f`).
+- Browser QA release under review: `v2.2.0` (`1434cb6`).
+- Canonical driver: `teibto-dev-standards v0.83.0` (`3868281`).
 - Performance runs: Windows host, Chrome `151.0.7922.140`, 2026-08-22.
 - Issue #69 revalidation: Windows host, Chrome `151.0.7922.174`, 2026-08-30; local driver file
   blob `21bf0cb72adaee04633c21a1c5758cbbf7a4da96` from worktree commit `b745196`.
-- The tested `scripts/cdp.py` blob was `ce5b376df249cb479f902751bbbb4df7898889d0`, identical to
-  the blob at canonical tag `v0.82.0`.
+- The pinned `scripts/cdp.py` blob is `28ca9e4a6475639f102d24a1cb2aab2dc736a3c9`, identical to
+  the blob at canonical tag `v0.83.0`.
 - Driver internals are owned by canonical `tests/test-cdp.sh`; this repository keeps thin consumer
   checks in `self-test/smoke-test.sh` plus runner unit/live tests.
 
@@ -28,7 +28,8 @@ Status terms:
 
 | Claim | Status | Evidence |
 |---|---|---|
-| Runner requires `teibto-cdp-jsonl` protocol v2+ and verifies `input-settle=none` | verified | `tests/test_flow_runner.py` protocol/incompatibility cases |
+| Runner requires `teibto-cdp-jsonl` protocol v3+ and verifies `input-settle=none` | verified, version-pinned | unit incompatibility cases plus live consumer gate against v0.83.0 |
+| Structured per-command dialogs are attributed once to the causing step | verified, version-pinned | unit structured-payload/malformed-payload cases plus v0.83.0 live alert fixture |
 | Event-bound navigation waits for the new main-frame commit/load and fails on cancel/timeout | verified | canonical `tests/test-cdp.sh` T16c–T16j; runner live test |
 | Collector is installed before next-document scripts and resets per page | verified | canonical T15/T16d; `self-test/smoke-test.sh` console checks |
 | Fast input settle is scoped to direct runner input; `pick`/`lens` retain normal settle | verified | canonical session probe T19u/v |
@@ -49,6 +50,7 @@ The comparison measures summed live step time, excluding Chrome startup:
 | protocol-v2 candidate | 20 fresh child sessions on one temporary Chrome target | 622.523 ms | 20/20 pass |
 | issue #54 revalidation | 20 fresh child sessions on one temporary Chrome target | 972.687 ms | 20/20 pass |
 | issue #69 current-host revalidation | 20 fresh child sessions on one temporary Chrome target | 618.904 ms | 20/20 pass |
+| issue #68 exact v0.83.0 pin | 20 fresh child sessions on one temporary Chrome target | 743.579 ms | 20/20 pass; per-step alert dialog |
 
 Measured improvement: **85.8%**. Candidate medians were startup 181.014 ms, open 30.552 ms, fill
 171.488 ms, click 396.767 ms, and total run 823.390 ms. The fixture intentionally waits 150/300 ms
@@ -60,14 +62,20 @@ does not replace the controlled release comparison or create a cross-machine lat
 
 The issue #69 medians were startup 174.502 ms, open 24.486 ms, fill 215.526 ms, click 385.726 ms,
 and total run 826.889 ms. The 618.904 ms step flow is 85.8% below the 4,373.865 ms historical baseline;
-450 ms remains intentional fixture latency. This run used the exact local driver blob recorded above
-and does not change the repository's v0.82.0 compatibility pin (that bump is tracked separately).
+450 ms remains intentional fixture latency. This run used the issue #69 local driver blob recorded
+above and preceded the repository's v0.83.0 compatibility pin.
 
 A controlled issue #69 regression check alternated 20 main/branch pairs after warm-up against the same
 Chrome target and the same pre-feature flow. Main versus branch medians were startup 309.575/310.072 ms
 (+0.2%), step flow 664.736/670.078 ms (+0.8%), and total 1,020.245/1,044.795 ms (+2.4%). This bounds
 the feature overhead on the measured host and explains why standalone runs at different times are not
 a valid before/after comparison.
+
+The issue #68 exact-tag revalidation used Chrome 151.0.7922.174 and canonical driver blob
+`28ca9e4a6475639f102d24a1cb2aab2dc736a3c9`. Medians were startup 414.374 ms, open 62.663 ms,
+fill 235.235 ms, click 442.186 ms, step flow 743.579 ms, and total 1,208.506 ms. All 20 runs
+attributed one live alert exactly once to step 3. This fixture adds a dialog round trip, so its absolute
+time is compatibility evidence, not a direct latency regression comparison with earlier rows.
 
 Absolute milliseconds are evidence for this host, not a cross-machine CI budget. The portable driver
 gate is ratio-based in canonical `tests/cdp-session-probe.py`. Reproduce with:

--- a/references/commands.md
+++ b/references/commands.md
@@ -1,7 +1,7 @@
 # Command Reference — `cdp.py` (CDP ตรง)
 
 transport ของ skill นี้คือ **`cdp.py`** ซึ่งเป็น asset กลางของ `Teibto/teibto-dev-standards`
-(`scripts/cdp.py`). Flow runner ต้องใช้ JSONL protocol v2+; ad-hoc command ใช้ policy ปกติของ driver.
+(`scripts/cdp.py`). Flow runner ต้องใช้ JSONL protocol v3+; ad-hoc command ใช้ policy ปกติของ driver.
 
 ## เตรียม (ครั้งเดียวต่อเครื่อง)
 

--- a/references/flow-spec.md
+++ b/references/flow-spec.md
@@ -16,7 +16,7 @@ $env:TEIBTO_CDP_SCRIPT = 'D:\path\to\teibto-dev-standards\scripts\cdp.py'
 
 - flow ทุกไฟล์ผ่าน `schemas/flow.schema.json` และ field ที่ไม่รู้จักทำให้หยุดทันที
 - secret ส่งผ่าน stdin (`--vars-json -`), ไม่อยู่ใน process argv/log/report
-- หนึ่ง run ใช้ target ที่ pin และ `cdp.py` JSONL protocol v2+ เพียง process/WebSocket เดียว;
+- หนึ่ง run ใช้ target ที่ pin และ `cdp.py` JSONL protocol v3+ เพียง process/WebSocket เดียว;
   runner ขอ `--input-settle=none` และ verify policy จาก ready handshake แบบ fail closed
 - `open` รอ main-frame commit/load event จริง; ไม่ใช้ zero-drain + `readyState` ที่อาจอ่านหน้าเก่า
 - `click` ใช้ native input เท่านั้น; ไม่มี JS fallback เงียบ
@@ -84,14 +84,16 @@ action แล้วรอ URL/time origin เปลี่ยนพร้อม `
 Oracle JET ให้ใช้ selector หรือ `fn:<observable outcome>` เช่น
 `fn:document.querySelector('#status').textContent==='saved'` แล้ว assert ครั้งเดียว.
 
-Dialog: cdp.py พิมพ์ `[dialog] <kind>: <message> -> accept|dismiss` ลง stderr ทุกครั้งที่ตอบ dialog;
-runner แปลงเป็น event `{"type":"dialog","scenario","index","global_index","kind","message","answer","line"}`,
+Dialog: cdp.py protocol v3 แนบ `dialogs: [{type,message,answer}]` ใน result ของ command ที่ตอบ dialog
+และพิมพ์ `[dialog] <kind>: <message> -> accept|dismiss` ลง stderr ทันที. Runner ใช้ structured result
+เป็น authority (stderr ใช้ diagnosis เท่านั้น จึงไม่เกิด event ซ้ำ/race) แล้วแปลงเป็น event
+`{"type":"dialog","scenario","index","global_index","kind","message","answer","line"}`,
 นับรวมใน `run_done.dialogs` และสรุปใน report เป็น
 `**Auto-answered dialogs:** <n> (policy: <policy>)`. `run_start.driver_policy.dialog` บอก policy ที่ใช้จริง;
+`run_start.driver_policy.dialog_evidence` เป็น `structured-per-command`;
 default `safe` (alert = accept, อย่างอื่น = dismiss) และเปลี่ยนได้เฉพาะ `--dialog` ของ runner —
-QA run ไม่ inherit `DIALOG` จาก shell ตาม SKILL.md invariant 5. cdp.py v2 (v0.82) พิมพ์ ledger นี้ตอนปิด
-session จึงได้ event ที่ `scenario`/`index` เป็น `null` และหัวข้อ "Auto-answered dialogs (reported by
-the driver at session close)" ท้าย report; ถ้า driver รายงานระหว่าง step runner จะผูกกับ step นั้นให้เอง.
+QA run ไม่ inherit `DIALOG` จาก shell ตาม SKILL.md invariant 5. ทุก dialog จึงผูกกับ step/command
+ที่ทำให้เกิดได้โดยตรง; payload ที่ shape ผิดทำให้ `INVALID_SESSION_OUTPUT` แทนการทิ้ง evidence เงียบ ๆ.
 
 `run-log.jsonl` เก็บ runner wall-clock และ authoritative driver `duration_ms`/`attempts` แยก
 `action`, `wait`, `assert`, `capture`; failure มี partial phases + `failing_phase`, console check มี

--- a/references/gotchas.md
+++ b/references/gotchas.md
@@ -55,7 +55,7 @@ handler ของแอปอาจไม่ทำงานด้วยเหต
   คนละเรื่อง · เจอ error นี้ให้ `nav` ซ้ำ หรือ inject collector เอง
 - **collector ตายพร้อมหน้า** — navigate แล้ว log เริ่มใหม่ · **นี่คือพฤติกรรมที่ต้องการ**:
   buffer สะสมข้ามหน้าจะทำให้ error ของหน้าก่อนถูกนับเป็นของหน้าปัจจุบัน.
-- `cdp.py` protocol v2 register collector ด้วย `Page.addScriptToEvaluateOnNewDocument` ก่อน `nav`
+- `cdp.py` protocol v3 register collector ด้วย `Page.addScriptToEvaluateOnNewDocument` ก่อน `nav`
   ใน connection เดียวกัน จึงจับ load-time error ได้; post-nav eval ใช้ verify/fallback
 - **หน้าที่เปิด/เปลี่ยนไปก่อน connection ปัจจุบัน register collector ยังจับย้อนหลังไม่ได้** — เช่น
   คนเปิดแท็บไว้ก่อน หรือ one-shot `nav` จบแล้วแอป navigate เองภายหลัง · `console` จะ error ไม่ใช่ `[]`
@@ -344,4 +344,3 @@ c.nav(URL + "?qa=" + str(int(time.time())))   # cache-bust ทุกรอบ
 
 ตัวชี้ขาดว่าเจอกับดักนี้: เปิด URL พร้อม query ใหม่แล้วผลเปลี่ยนทันที · เจอจริง 2026-08-15
 (#117 ของ ERP-AI-First) เสียเวลาไปหนึ่งรอบเต็มกับการยืนยันว่า fix ที่ถูกอยู่แล้ว "ไม่ทำงาน"
-

--- a/references/reliability-policy.md
+++ b/references/reliability-policy.md
@@ -33,7 +33,7 @@ process. การ retry ทั้ง scenario ต้องเป็นการ
   retry: แก้ด้วย `wait "<เงื่อนไขผลลัพธ์>"` ก่อน assert (gotchas.md §2)
   แล้ว assert **ครั้งเดียว**. อย่าเปลี่ยน "รอให้ถูก" เป็น "ยิงซ้ำจนบังเอิญผ่าน".
 
-Runner protocol v2 ตัด fixed input settle เฉพาะ `click`/`fill`/`press` ที่ runner ส่งตรง. `fill`
+Runner protocol v3 ตัด fixed input settle เฉพาะ `click`/`fill`/`press` ที่ runner ส่งตรง. `fill`
 จึง poll ค่า exact แบบ bounded หลัง action; click/press ต้องมี `wait` ของ observable outcome ก่อน
 assert. เวลาของแอปยังอยู่ใน action/wait timing ไม่ได้ถูกลบออก. `networkidle` ใช้เฉพาะ navigation-ready;
 AJAX/component state ใช้ selector หรือ `fn:<js>` ที่เจาะจง.

--- a/scripts/flow-runner.py
+++ b/scripts/flow-runner.py
@@ -43,13 +43,11 @@ PLACEHOLDER = re.compile(r"\{\{\s*([A-Za-z_][A-Za-z0-9_]*)\s*\}\}")
 MUTATING_ACTIONS = {"click", "select", "press", "eval"}
 MAX_EVENT_TEXT = 2_000
 SESSION_PROTOCOL = "teibto-cdp-jsonl"
-MIN_SESSION_VERSION = 2
+MIN_SESSION_VERSION = 3
 INPUT_SETTLE_POLICY = "none"
 DIALOG_POLICIES = ("safe", "accept", "dismiss")
 STDOUT_MODES = ("events", "summary")
 SUMMARY_EVENT_TYPES = {"fatal", "run_done"}
-# cdp.py prints every auto-answered dialog to stderr as "[dialog] <kind>: <message> -> <answer>".
-DIALOG_LINE = re.compile(r"^\[dialog\] (?P<kind>[^:]+): (?P<message>.*) -> (?P<answer>\S+)$")
 
 
 class RunnerError(RuntimeError):
@@ -254,14 +252,29 @@ class CDPSession:
             text = line.rstrip()
             if len(self.stderr) < 200:
                 self.stderr.append(text)
-            match = DIALOG_LINE.match(text)
-            if match:
-                self.dialogs.put({**match.groupdict(), "line": text})
-            elif text.startswith("[dialog]"):
-                self.dialogs.put({"kind": "unknown", "message": text, "answer": "unknown", "line": text})
+
+    def _record_dialogs(self, payload: dict[str, Any]) -> None:
+        """Validate protocol-v3 per-command dialogs and queue them for step attribution."""
+        items = payload.get("dialogs")
+        if items is None:
+            return
+        if not isinstance(items, list):
+            raise RunnerError("INVALID_SESSION_OUTPUT", "CDP session dialogs ต้องเป็น array")
+        validated: list[dict[str, str]] = []
+        for item in items:
+            if not isinstance(item, dict):
+                raise RunnerError("INVALID_SESSION_OUTPUT", "CDP session dialog ต้องเป็น object")
+            kind, message, answer = item.get("type"), item.get("message"), item.get("answer")
+            if (not isinstance(kind, str) or not isinstance(message, str)
+                    or answer not in ("accept", "dismiss")):
+                raise RunnerError("INVALID_SESSION_OUTPUT", "CDP session dialog shape ไม่ถูกต้อง")
+            validated.append({"kind": kind, "message": message, "answer": answer,
+                              "line": f"[dialog] {kind}: {message} -> {answer}"})
+        for item in validated:
+            self.dialogs.put(item)
 
     def drain_dialogs(self) -> list[dict[str, str]]:
-        """Dialogs the driver answered since the previous drain (stderr arrives asynchronously)."""
+        """Protocol-v3 dialogs answered by commands since the previous drain."""
         items: list[dict[str, str]] = []
         while True:
             try:
@@ -305,6 +318,7 @@ class CDPSession:
                 raise RunnerError("SESSION_CLOSED", f"CDP session ปิด: {payload.get('reason')}", detail=payload)
             if payload.get("id") != request_id:
                 raise RunnerError("CORRELATION_MISMATCH", "CDP response id ไม่ตรงกับ request", detail=payload)
+            self._record_dialogs(payload)
             if not payload.get("ok"):
                 error = payload.get("error") or {}
                 raise RunnerError(error.get("code", "CDP_COMMAND_FAILED"),
@@ -331,8 +345,8 @@ class CDPSession:
                 self.process.kill()
                 self.process.wait(timeout=3)
         finally:
-            # cdp.py reports the dialogs it answered on stderr at close; make sure the reader
-            # has consumed that tail before the caller drains dialogs for the report.
+            # Keep stderr complete for diagnostics. Dialog evidence itself comes from the
+            # protocol-v3 result payload, so stderr timing cannot create duplicates or races.
             self._stderr_thread.join(timeout=3)
 
 
@@ -568,6 +582,7 @@ def run_flow(flow: dict[str, Any], path: Path, output_dir: Path, variables: dict
                                  "min_version": MIN_SESSION_VERSION,
                                  "input_settle": INPUT_SETTLE_POLICY,
                                  "dialog": dialog,
+                                 "dialog_evidence": "structured-per-command",
                                  "navigation": "event-bound-load"},
                "scenarios": [{"id": item["id"], "steps": len(item["steps"])}
                              for item in flow["scenarios"]]})
@@ -725,17 +740,6 @@ def run_flow(flow: dict[str, Any], path: Path, output_dir: Path, variables: dict
     finally:
         if session:
             session.close()
-            # Current cdp.py session mode prints its dialog ledger only at close, so these
-            # cannot be attributed to a step; they are still evidence and still counted.
-            late = session.drain_dialogs()
-            if late:
-                report.extend(["## Auto-answered dialogs (reported by the driver at session close)", ""])
-                for item in late:
-                    dialogs += 1
-                    sink.emit({"type": "dialog", "scenario": None, "index": None,
-                               "global_index": None, **item})
-                    report.append(f"- ⚠️ dialog {item['kind']}: \"{item['message']}\" -> {item['answer']}")
-                report.append("")
 
     verdict = "FAIL" if failures else ("UNVERIFIED" if unverified else "PASS")
     summary = [f"**Verdict:** {verdict}", f"**Assertions:** {passed}/{assertions} passed",

--- a/self-test/smoke-test.sh
+++ b/self-test/smoke-test.sh
@@ -6,7 +6,7 @@
 #
 # ต้องมี: Chrome + `py -m pip install websocket-client` (pillow/numpy ถ้าจะเทส diff)
 # ไม่มี Chrome = SKIP (exit 0) ไม่ใช่ FAIL
-# transport: canonical cdp.py protocol v2+ (direct CDP)
+# transport: canonical cdp.py protocol v3+ (direct CDP)
 set -u
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/tests/fixtures/fake_cdp.py
+++ b/tests/fixtures/fake_cdp.py
@@ -20,42 +20,32 @@ if os.environ.get("FAKE_CDP_REJECT_INPUT_SETTLE") and input_settle != "fixed":
                                 "transient": False}}), flush=True)
     raise SystemExit(2)
 print(json.dumps({"type": "ready", "ok": True, "protocol": "teibto-cdp-jsonl",
-                  "version": int(os.environ.get("FAKE_CDP_VERSION", "2")),
+                  "version": int(os.environ.get("FAKE_CDP_VERSION", "3")),
                   "input_settle": input_settle, "target_id": target, "port": 9222}), flush=True)
 values = {}
 url = "about:blank"
 # FAKE_CDP_DIALOG=<kind>:<message> makes every click raise that dialog; the answer follows the
-# DIALOG policy the way cdp.py does (safe = dismiss anything that is not an alert). Like the
-# real driver the ledger is printed to stderr at close; FAKE_CDP_DIALOG_WHEN=click prints it
-# live instead (a future driver behaviour the runner attributes per step).
+# DIALOG policy the way protocol v3 does (safe = dismiss anything that is not an alert).
+# The result carries structured dialogs and stderr reports each one immediately.
 dialog_spec = os.environ.get("FAKE_CDP_DIALOG")
 dialog_policy = os.environ.get("DIALOG", "safe")
-dialog_when = os.environ.get("FAKE_CDP_DIALOG_WHEN", "close")
-dialog_ledger = []
-
-
-def report_dialogs():
-    for line in dialog_ledger:
-        sys.stderr.write(line)
-    sys.stderr.flush()
-    dialog_ledger.clear()
 for line in sys.stdin:
     request = json.loads(line)
     if request.get("type") == "close":
         print(json.dumps({"type": "closed", "id": request.get("id"), "ok": True,
                           "reason": "requested", "target_id": target}), flush=True)
-        report_dialogs()
         break
     command, args = request["command"], request.get("args", [])
+    command_dialogs = []
     if command == "click" and dialog_spec:
         kind, message = dialog_spec.split(":", 1)
         if dialog_policy == "safe":
             answer = "accept" if kind == "alert" else "dismiss"
         else:
             answer = dialog_policy
-        dialog_ledger.append(f"[dialog] {kind}: {message} -> {answer}\n")
-        if dialog_when == "click":
-            report_dialogs()
+        command_dialogs.append({"type": kind, "message": message, "answer": answer})
+        sys.stderr.write(f"[dialog] {kind}: {message} -> {answer}\n")
+        sys.stderr.flush()
     if command == "nav":
         url = args[0]
         data = url
@@ -81,6 +71,11 @@ for line in sys.stdin:
         data = args[0]
     else:
         data = True
-    print(json.dumps({"type": "result", "id": request["id"], "ok": True,
-                      "command": command, "target_id": target, "duration_ms": 0.1,
-                      "attempts": 1, "data": data}), flush=True)
+    payload = {"type": "result", "id": request["id"], "ok": True,
+               "command": command, "target_id": target, "duration_ms": 0.1,
+               "attempts": 1, "data": data}
+    if command_dialogs:
+        payload["dialogs"] = command_dialogs
+    if command == "click" and os.environ.get("FAKE_CDP_BAD_DIALOGS"):
+        payload["dialogs"] = "not-an-array"
+    print(json.dumps(payload), flush=True)

--- a/tests/fixtures/live-page.html
+++ b/tests/fixtures/live-page.html
@@ -7,6 +7,7 @@
 <script>
 document.getElementById('save').addEventListener('click', function (event) {
   var trusted = event.isTrusted;
+  alert('Live save started');
   setTimeout(function () {
     document.getElementById('status').textContent =
       (trusted ? 'saved ' : 'untrusted ') + document.getElementById('name').value;

--- a/tests/test-flow-runner-live.sh
+++ b/tests/test-flow-runner-live.sh
@@ -93,7 +93,7 @@ for run in range(1, count + 1):
     events = [json.loads(line) for line in
               (work / f"out-{run}" / "run-log.jsonl").read_text(encoding="utf-8").splitlines()]
     ready = next(item for item in events if item["type"] == "session_ready")
-    assert ready["version"] >= 2 and ready["input_settle"] == "none", ready
+    assert ready["version"] >= 3 and ready["input_settle"] == "none", ready
     steps = [item for item in events if item["type"] == "step_done"]
     assert len(steps) == 3 and all(item["status"] != "fail" for item in steps), steps
     fill = steps[1]["timings"]["phases"]
@@ -106,8 +106,16 @@ for run in range(1, count + 1):
     assert steps[2]["performance"]["verdict"] == "PASS", steps[2]
     assert 280 <= steps[2]["performance"]["outcome_ms"] <= 10000, steps[2]
     assert next(item for item in events if item["type"] == "errors").get("timing"), events
+    dialogs = [item for item in events if item["type"] == "dialog"]
+    assert len(dialogs) == 1, dialogs
+    assert {key: dialogs[0][key] for key in
+            ("scenario", "index", "global_index", "kind", "message", "answer")} == {
+                "scenario": "native-click", "index": 3, "global_index": 3,
+                "kind": "alert", "message": "Live save started", "answer": "accept",
+            }, dialogs[0]
     done = next(item for item in events if item["type"] == "run_done")
     assert done["verdict"] == "PASS", done
+    assert done["dialogs"] == 1, done
     assert done["performance_budgets"] == {"passed": 1, "evaluated": 1, "total": 1}, done
     terminal = [json.loads(line) for line in
                 (work / f"runner-{run}.jsonl").read_text(encoding="utf-8").splitlines()]
@@ -122,4 +130,4 @@ print(json.dumps({"runs": count, "failures": 0,
 PY
 if grep -R -q 's3cret-Ada' "${WORK}"/out-*/run-log.jsonl; then exit 1; fi
 if grep -R -q 's3cret-Ada' "${WORK}"/out-*/qa-report.md; then exit 1; fi
-echo "PASS: ${LIVE_RUNS} real-Chrome run(s) used protocol v2, event-bound nav, fast native input, async waits, performance budgets, summary stdout, redaction, telemetry, and artifacts"
+echo "PASS: ${LIVE_RUNS} real-Chrome run(s) used protocol v3, per-step dialogs, event-bound nav, fast native input, async waits, performance budgets, summary stdout, redaction, telemetry, and artifacts"

--- a/tests/test_flow_runner.py
+++ b/tests/test_flow_runner.py
@@ -78,7 +78,7 @@ class FlowRunnerTests(unittest.TestCase):
         self.assertIn('"verdict":"PASS"', events)
         payloads = [json.loads(line) for line in events.splitlines()]
         ready = next(item for item in payloads if item["type"] == "session_ready")
-        self.assertEqual(2, ready["version"])
+        self.assertEqual(3, ready["version"])
         self.assertEqual("none", ready["input_settle"])
         self.assertEqual(str(FAKE_CDP), ready["cdp_script"])
         self.assertGreaterEqual(ready["duration_ms"], 0)
@@ -265,11 +265,11 @@ class FlowRunnerTests(unittest.TestCase):
               - id: smoke
                 steps:
                   - {action: open, target: "https://example.test", capture: false}
-        """, env_overrides={"FAKE_CDP_VERSION": "1"})
+        """, env_overrides={"FAKE_CDP_VERSION": "2"})
         self.assertEqual(1, process.returncode)
         events = (out / "run-log.jsonl").read_text(encoding="utf-8")
         self.assertIn("DRIVER_INCOMPATIBLE", events)
-        self.assertIn("v2+", events)
+        self.assertIn("v3+", events)
         fatal = next(json.loads(line) for line in events.splitlines()
                      if '"type":"fatal"' in line)
         self.assertIn(str(FAKE_CDP), fatal["error"]["message"])
@@ -300,8 +300,8 @@ class FlowRunnerTests(unittest.TestCase):
                     assert: {target: "#notice", contains: "saved"}
                     capture: false
         """
-        # A stale DIALOG=accept in the shell must not leak into the QA session. The current
-        # driver prints its dialog ledger at session close, so the evidence is run-level.
+        # A stale DIALOG=accept in the shell must not leak into the QA session. Protocol v3
+        # attaches structured dialogs to the command result; stderr must not duplicate them.
         process, out, _ = self.run_flow(flow, env_overrides={
             "FAKE_CDP_DIALOG": "confirm:Delete this record?", "DIALOG": "accept"})
         self.assertEqual(0, process.returncode, process.stdout + process.stderr)
@@ -309,26 +309,21 @@ class FlowRunnerTests(unittest.TestCase):
                     (out / "run-log.jsonl").read_text(encoding="utf-8").splitlines()]
         start = next(item for item in payloads if item["type"] == "run_start")
         self.assertEqual("safe", start["driver_policy"]["dialog"])
-        dialog = next(item for item in payloads if item["type"] == "dialog")
-        self.assertEqual({"scenario": None, "index": None, "kind": "confirm",
+        self.assertEqual("structured-per-command", start["driver_policy"]["dialog_evidence"])
+        dialog_events = [item for item in payloads if item["type"] == "dialog"]
+        self.assertEqual(1, len(dialog_events))
+        dialog = dialog_events[0]
+        self.assertEqual({"scenario": "delete", "index": 2, "global_index": 2,
+                          "kind": "confirm",
                           "message": "Delete this record?", "answer": "dismiss"},
                          {key: dialog[key] for key in
-                          ("scenario", "index", "kind", "message", "answer")})
+                          ("scenario", "index", "global_index", "kind", "message", "answer")})
         done = next(item for item in payloads if item["type"] == "run_done")
         self.assertEqual(1, done["dialogs"])
         report = (out / "qa-report.md").read_text(encoding="utf-8")
         self.assertIn('dialog confirm: "Delete this record?" -> dismiss', report)
         self.assertIn("**Auto-answered dialogs:** 1 (policy: safe)", report)
-
-        # A driver that reports dialogs while the step runs gets per-step attribution.
-        process, out, _ = self.run_flow(flow, env_overrides={
-            "FAKE_CDP_DIALOG": "confirm:Delete this record?", "FAKE_CDP_DIALOG_WHEN": "click"})
-        self.assertEqual(0, process.returncode, process.stdout + process.stderr)
-        payloads = [json.loads(line) for line in
-                    (out / "run-log.jsonl").read_text(encoding="utf-8").splitlines()]
-        dialog = next(item for item in payloads if item["type"] == "dialog")
-        self.assertEqual(("delete", 2, 2), (dialog["scenario"], dialog["index"], dialog["global_index"]))
-        self.assertEqual(1, next(item for item in payloads if item["type"] == "run_done")["dialogs"])
+        self.assertNotIn("reported by the driver at session close", report)
 
         # The policy changes only through the explicit runner flag.
         process, out, _ = self.run_flow(flow, env_overrides={
@@ -337,6 +332,25 @@ class FlowRunnerTests(unittest.TestCase):
         events = (out / "run-log.jsonl").read_text(encoding="utf-8")
         self.assertIn('"answer":"accept"', events)
         self.assertIn('"dialog":"accept"', events)
+
+    def test_malformed_protocol_v3_dialogs_fail_closed(self):
+        process, out, _ = self.run_flow("""
+            story: bad-dialogs
+            title: Bad protocol-v3 dialogs
+            scenarios:
+              - id: save
+                steps:
+                  - action: click
+                    target: "#save"
+                    assert: {target: "#notice", contains: "saved"}
+                    capture: false
+        """, env_overrides={"FAKE_CDP_BAD_DIALOGS": "1"})
+        self.assertEqual(1, process.returncode)
+        payloads = [json.loads(line) for line in
+                    (out / "run-log.jsonl").read_text(encoding="utf-8").splitlines()]
+        step = next(item for item in payloads if item["type"] == "step_done")
+        self.assertEqual("INVALID_SESSION_OUTPUT", step["error"]["code"])
+        self.assertEqual("action", step["timings"]["failing_phase"])
 
     def test_capture_defaults_follow_doc_mode_and_failure_evidence(self):
         passed, passed_out, _ = self.run_flow("""


### PR DESCRIPTION
## Summary

- bump `TEIBTO_DEV_STANDARDS_REF` to canonical v0.83.0 and require JSONL protocol v3+
- consume structured per-command `result.dialogs` as the evidence authority while retaining stderr for diagnosis
- attribute every dialog exactly once to the causing step; malformed dialog payloads fail closed
- update current install/contributor/architecture/flow guidance and version-pinned claims

## Exact-tag evidence

- canonical tag commit: `3868281b85f58f408fcb8bce21b32b2e2d207e48`
- canonical `scripts/cdp.py` blob: `28ca9e4a6475639f102d24a1cb2aab2dc736a3c9`
- live Chrome: 20/20 runs passed with one alert attributed exactly once to scenario `native-click`, step/global index 3
- live medians: startup 414.374 ms; step flow 743.579 ms; total 1,208.506 ms (includes the new alert round trip and 450 ms intentional app delay)

## Verification

- `python -m unittest discover -s tests -v` — 27 passed
- `tests/test-flow-runner-live.sh` with exact v0.83.0 and `LIVE_RUNS=20` — 20/20 pass
- `self-test/smoke-test.sh` with exact v0.83.0 — 41 passed, 0 failed
- `python scripts/validate-skill.py` — pass
- `python scripts/build-skill.py` — pass (27 entries)
- `node --check app/server.js` — pass
- `git diff --check` — pass

Closes #68