### PR TITLE
chore(release): prepare v2.3.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ## [Unreleased]
 
+## [2.3.0] - 2026-08-30
+
+**Token-safe performance budgets with protocol-v3 dialog attribution and pinned driver compatibility.**
+
 ### Added
 
 - Token-safe runner stdout (`--stdout summary`) preserves the complete `run-log.jsonl` while returning


### PR DESCRIPTION
## Summary

- move the merged Unreleased changes into a dated v2.3.0 section
- add the one-line release summary consumed by the tag workflow
- keep Unreleased empty for future changes

## Verification

- python -m unittest discover -s tests -v (27/27 passed)
- python scripts/validate-skill.py
- python scripts/build-skill.py (27 entries)
- scripts/publish-release.sh v2.3.0 --dry-run (body extracted correctly)

Closes #72