### PR TITLE
fix(runner): require foreground-ready sessions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,10 @@ permissions:
   contents: read
 
 env:
-  # Canonical driver generation this runner is verified against (JSONL protocol v3+).
-  # Bump deliberately together with README/CONTRIBUTING; driver-compat runs the live test
-  # against exactly this tag of Teibto/teibto-dev-standards.
-  TEIBTO_DEV_STANDARDS_REF: v0.83.0
+  # Temporary immutable pin to teibto-dev-standards PR #277 while its release is blocked by #274.
+  # Before this browser PR leaves draft, replace the SHA with the reviewed release tag and update
+  # README/CONTRIBUTING/CLAIMS-AUDIT in the same commit.
+  TEIBTO_DEV_STANDARDS_REF: 56b4e788ab80807c3f62b43b88a151a52a96df8e
 
 jobs:
   quality-gate:
@@ -90,7 +90,7 @@ jobs:
             exit 1
           fi
 
-      - name: Checkout canonical driver at the pinned tag
+      - name: Checkout canonical driver at the pinned revision
         if: steps.access.outputs.available == 'true'
         uses: actions/checkout@v5
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Runner fail closed ก่อนเริ่ม flow ถ้า canonical driver ไม่แนบ foreground-ready evidence หรือ target
+  ที่ pin ยัง hidden; real-Chrome consumer gate บังคับแท็บคู่แข่งให้ active ก่อนทุก run แล้วพิสูจน์ว่า
+  driver foreground target ที่ถูกต้อง ป้องกัน NetSuite background-timer throttle และ performance
+  baseline ช้าปลอม (#74).
+
 ## [2.3.0] - 2026-08-30
 
 **Token-safe performance budgets with protocol-v3 dialog attribution and pinned driver compatibility.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,9 @@
 - Runner fail closed ก่อนเริ่ม flow ถ้า canonical driver ไม่แนบ foreground-ready evidence หรือ target
   ที่ pin ยัง hidden; real-Chrome consumer gate บังคับแท็บคู่แข่งให้ active ก่อนทุก run แล้วพิสูจน์ว่า
   driver foreground target ที่ถูกต้อง ป้องกัน NetSuite background-timer throttle และ performance
-  baseline ช้าปลอม (#74).
+  baseline ช้าปลอม. Fresh authenticated SB2 MRP measurement จบที่ 31.310 วินาทีเมื่อ foreground-ready
+  เทียบกับ background/recovery 644.391 วินาที (ลด elapsed 95.1%) โดยผล 10,020 แถว สถานะ คำเตือน
+  และ error ตรงกัน; รอบช้าจบหลัง foreground recovery ไม่ได้จบขณะ hidden (#74).
 
 ## [2.3.0] - 2026-08-30
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,8 +6,9 @@ How to change this skill without breaking the discipline it is built on. New her
 ## Prerequisites
 
 - Chrome + `py -m pip install websocket-client pillow numpy` — needed to run `self-test/smoke-test.sh`.
-  Use canonical `cdp.py` protocol v3+ (v0.83.0 or newer); override the standard team path with
-  `NS_CDP` for smoke tests or `TEIBTO_CDP_SCRIPT` for the flow runner.
+  Use canonical `cdp.py` protocol v3+ with foreground-ready evidence (`foreground=true` and
+  `visibility_state=visible`); v0.83.0 has protocol v3 but predates those fields. Override the standard
+  team path with `NS_CDP` for smoke tests or `TEIBTO_CDP_SCRIPT` for the flow runner.
 - Python 3.10+ with PyYAML/jsonschema: `pip install -r requirements.txt` — for the `scripts/`.
 - Node.js 20+ only when changing the optional local UI.
 - Optional: `pymupdf` (for `self-test/pdf/pdf-test.sh`).
@@ -71,9 +72,10 @@ Re-run after any Chrome or `cdp.py` version bump — this is the drift detector.
 ### Driver pin and the `driver-compat` CI job
 
 The runner is verified against one canonical driver generation: `TEIBTO_DEV_STANDARDS_REF` in
-`.github/workflows/ci.yml` (currently `v0.83.0`, the first `teibto-dev-standards` tag with JSONL
-protocol v3 and structured per-command dialogs). CI job `driver-compat` clones that exact tag and runs
-`tests/test-flow-runner-live.sh`
+`.github/workflows/ci.yml`. While the foreground-ready driver change is under review, this is the
+immutable commit `56b4e788ab80807c3f62b43b88a151a52a96df8e`; replace it with that change's reviewed
+release tag before this browser PR leaves Draft. CI job `driver-compat` clones that exact revision and
+runs `tests/test-flow-runner-live.sh`
 in real Chrome on every pull request, so driver drift fails before merge instead of on a developer
 machine. `teibto-dev-standards` is private: the job needs the repository secret
 `DEV_STANDARDS_DEPLOY_KEY` — the private half of a **read-only deploy key** registered on that repository

--- a/README.md
+++ b/README.md
@@ -53,11 +53,14 @@ py -m pip install -r requirements.txt
 py -m pip install websocket-client pillow numpy
 ```
 
-The flow runner requires canonical `cdp.py` JSONL protocol v3 or newer, first released in
-[`teibto-dev-standards v0.83.0`](https://github.com/Teibto/teibto-dev-standards/releases/tag/v0.83.0).
-Pass its path with `--cdp-script` or `TEIBTO_CDP_SCRIPT`. The runner also checks the standard team
-installation path automatically. CI verifies every change against that pinned tag in real Chrome
-(`driver-compat` job; see [`CONTRIBUTING.md`](CONTRIBUTING.md)).
+The flow runner requires canonical `cdp.py` JSONL protocol v3 or newer **and** a ready handshake that
+proves the pinned target is foreground/visible. Protocol v3 first shipped in
+[`teibto-dev-standards v0.83.0`](https://github.com/Teibto/teibto-dev-standards/releases/tag/v0.83.0),
+but that tag predates the foreground-ready fields and is no longer sufficient for this runner.
+Pass the driver path with `--cdp-script` or `TEIBTO_CDP_SCRIPT`; the runner also checks the standard
+team installation path automatically. Until the foreground change receives a release tag, CI verifies
+against its immutable candidate commit under review in real Chrome (`driver-compat` job; see
+[`CONTRIBUTING.md`](CONTRIBUTING.md)).
 
 ## Quick smoke run
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -67,10 +67,11 @@ Use `a11y "<visible name>"` to obtain a semantic `@ref` when a stable selector i
 that it had no errors. Use `lens netlog` only inside a `run` that enabled `netlog on`.
 
 For repeatable flows, `scripts/flow-runner.py` validates the YAML schema, requires a pinned target,
-negotiates CDP JSONL protocol v3+, and owns one bounded `session --jsonl --input-settle=none` per run.
+negotiates CDP JSONL protocol v3+, requires ready evidence that the exact pinned target is
+foreground/visible, and owns one bounded `session --jsonl --input-settle=none` per run.
 It replaces fixed input sleeps with bounded outcome checks, keeps application latency visible in
 action/wait timing, and emits separate action/wait/assert/capture timings. The runner fails closed on an old
-driver, an unsupported field, an assertion failure, or missing evidence.
+driver, a hidden/background target, an unsupported field, an assertion failure, or missing evidence.
 For agent-run flows, pass `--stdout summary`; the complete event stream remains in `run-log.jsonl`.
 Use step-level `perf_budget_ms` when action-to-observable-outcome time is an acceptance criterion.
 

--- a/docs/CLAIMS-AUDIT.md
+++ b/docs/CLAIMS-AUDIT.md
@@ -7,10 +7,15 @@ history and `CHANGELOG.md`.
 ## Evidence boundary
 
 - Browser QA release under review: `v2.2.0` (`1434cb6`).
-- Canonical driver: `teibto-dev-standards v0.83.0` (`3868281`).
+- Canonical released driver: `teibto-dev-standards v0.83.0` (`3868281`).
+- Foreground-ready driver candidate: `teibto-dev-standards@56b4e788ab80807c3f62b43b88a151a52a96df8e`
+  (PR #277), `scripts/cdp.py` blob `6d9dcc7ea5a8a9a36a7138945dbece8a86a9177f`.
 - Performance runs: Windows host, Chrome `151.0.7922.140`, 2026-08-22.
 - Issue #69 revalidation: Windows host, Chrome `151.0.7922.174`, 2026-08-30; local driver file
   blob `21bf0cb72adaee04633c21a1c5758cbbf7a4da96` from worktree commit `b745196`.
+- Issue #74 revalidation: same Windows host, Chrome `151.0.7922.174`, 2026-08-30; foreground-ready
+  candidate commit/blob above. The candidate is not a released dependency until its upstream review,
+  CI, and release gates pass.
 - The pinned `scripts/cdp.py` blob is `28ca9e4a6475639f102d24a1cb2aab2dc736a3c9`, identical to
   the blob at canonical tag `v0.83.0`.
 - Driver internals are owned by canonical `tests/test-cdp.sh`; this repository keeps thin consumer
@@ -28,8 +33,9 @@ Status terms:
 
 | Claim | Status | Evidence |
 |---|---|---|
-| Runner requires `teibto-cdp-jsonl` protocol v3+ and verifies `input-settle=none` | verified, version-pinned | unit incompatibility cases plus live consumer gate against v0.83.0 |
-| Structured per-command dialogs are attributed once to the causing step | verified, version-pinned | unit structured-payload/malformed-payload cases plus v0.83.0 live alert fixture |
+| Runner requires protocol v3+, verifies `input-settle=none`, and requires foreground-ready fields | verified, version-pinned | missing/hidden unit cases plus 20-run two-tab live consumer gate against candidate `56b4e788` |
+| The exact pinned target is visible before any flow step while the competing tab becomes hidden | verified, version-pinned | canonical two-tab gate plus browser live test that re-hides the target before every run |
+| Structured per-command dialogs are attributed once to the causing step | verified, version-pinned | unit structured-payload/malformed-payload cases plus v0.83.0 and candidate live alert fixtures |
 | Event-bound navigation waits for the new main-frame commit/load and fails on cancel/timeout | verified | canonical `tests/test-cdp.sh` T16c–T16j; runner live test |
 | Collector is installed before next-document scripts and resets per page | verified | canonical T15/T16d; `self-test/smoke-test.sh` console checks |
 | Fast input settle is scoped to direct runner input; `pick`/`lens` retain normal settle | verified | canonical session probe T19u/v |
@@ -51,6 +57,7 @@ The comparison measures summed live step time, excluding Chrome startup:
 | issue #54 revalidation | 20 fresh child sessions on one temporary Chrome target | 972.687 ms | 20/20 pass |
 | issue #69 current-host revalidation | 20 fresh child sessions on one temporary Chrome target | 618.904 ms | 20/20 pass |
 | issue #68 exact v0.83.0 pin | 20 fresh child sessions on one temporary Chrome target | 743.579 ms | 20/20 pass; per-step alert dialog |
+| issue #74 foreground-ready candidate | 20 fresh child sessions; target hidden before every session | 653.229 ms | 20/20 pass; p95 739.154 ms |
 
 Measured improvement: **85.8%**. Candidate medians were startup 181.014 ms, open 30.552 ms, fill
 171.488 ms, click 396.767 ms, and total run 823.390 ms. The fixture intentionally waits 150/300 ms
@@ -76,6 +83,26 @@ The issue #68 exact-tag revalidation used Chrome 151.0.7922.174 and canonical dr
 fill 235.235 ms, click 442.186 ms, step flow 743.579 ms, and total 1,208.506 ms. All 20 runs
 attributed one live alert exactly once to step 3. This fixture adds a dialog round trip, so its absolute
 time is compatibility evidence, not a direct latency regression comparison with earlier rows.
+
+The final issue #74 live set used one temporary Chrome instance with a competing tab. Before each of
+20 sessions the harness activated the competing tab and proved the pinned target hidden; after runner
+startup it proved the pinned target visible and competitor hidden. Median/p95 milliseconds were:
+startup 294.828/414.997, open 41.049/67.821, fill 192.673/226.710, click 432.772/467.162,
+step flow 653.229/739.154, and total run 972.063/1,198.926. A preceding 20-run set also passed 20/20
+(median step flow 675.275 ms), so the final set was not a lone successful sample.
+
+The motivating anonymized NetSuite Suitelet/MRP evidence is recorded in canonical issue #276: the
+same-result foreground/background pairs were 34.784/389.246 seconds (about 11.2x) and
+31.094/160.035 seconds (about 5.1x). These are historical sandbox observations, not a controlled
+driver A/B and not a fresh authenticated NetSuite rerun. The mechanism is supported separately by
+the hidden/visible target proof and the client loop's `setTimeout(0)` behavior; no customer identifier
+is needed or retained here.
+
+Canonical PR #277 measured readiness overhead with 30 alternating same-host pairs: baseline/candidate
+median wall time 220.358/233.825 ms, +13.467 ms (about 6.1%) per session. Its synthetic headless
+fixture did not reproduce the background timer clamp, so this repository makes no synthetic speedup
+claim. The large speed-risk finding comes from the NetSuite observations above; the fixture gates the
+foreground invariant and bounds its startup cost.
 
 Absolute milliseconds are evidence for this host, not a cross-machine CI budget. The portable driver
 gate is ratio-based in canonical `tests/cdp-session-probe.py`. Reproduce with:

--- a/docs/CLAIMS-AUDIT.md
+++ b/docs/CLAIMS-AUDIT.md
@@ -16,6 +16,9 @@ history and `CHANGELOG.md`.
 - Issue #74 revalidation: same Windows host, Chrome `151.0.7922.174`, 2026-08-30; foreground-ready
   candidate commit/blob above. The candidate is not a released dependency until its upstream review,
   CI, and release gates pass.
+- Issue #74 authenticated NetSuite SB2 revalidation: same host/Chrome/date and one pinned MRP
+  Suitelet target. The run used read-only planning actions only; it did not submit Create PR/PO/WO or
+  mutate production data.
 - The pinned `scripts/cdp.py` blob is `28ca9e4a6475639f102d24a1cb2aab2dc736a3c9`, identical to
   the blob at canonical tag `v0.83.0`.
 - Driver internals are owned by canonical `tests/test-cdp.sh`; this repository keeps thin consumer
@@ -91,12 +94,29 @@ startup 294.828/414.997, open 41.049/67.821, fill 192.673/226.710, click 432.772
 step flow 653.229/739.154, and total run 972.063/1,198.926. A preceding 20-run set also passed 20/20
 (median step flow 675.275 ms), so the final set was not a lone successful sample.
 
-The motivating anonymized NetSuite Suitelet/MRP evidence is recorded in canonical issue #276: the
-same-result foreground/background pairs were 34.784/389.246 seconds (about 11.2x) and
-31.094/160.035 seconds (about 5.1x). These are historical sandbox observations, not a controlled
-driver A/B and not a fresh authenticated NetSuite rerun. The mechanism is supported separately by
-the hidden/visible target proof and the client loop's `setTimeout(0)` behavior; no customer identifier
-is needed or retained here.
+Fresh authenticated NetSuite SB2 evidence used the same MRP inputs and explicitly invalidated the
+page's last-run and BOM caches before each run:
+
+| Run | Visibility method | MRP elapsed | Observable result |
+|---|---|---:|---|
+| foreground cold | exact target visible throughout | 55.529 s | identical |
+| foreground warm | exact target visible throughout | 34.664 s | identical |
+| background/recovery | clicked visible, hidden after 0.683 s, foregrounded after 617.747 s | 644.391 s | identical after foreground recovery |
+| issue #74 runner + PR #277 driver | target hidden before session; ready foreground and visible throughout MRP | 31.310 s | identical |
+
+The background/recovery run did not complete while hidden: it exceeded the bounded 600-second wait,
+then finished about 26.6 seconds after the exact target returned to foreground. Its total was 18.59x
+the warm foreground run and 11.60x the cold foreground run. Starting the same flow through the
+foreground-ready contract completed in 31.310 seconds, 95.1% less elapsed time than that
+background/recovery run, and remained inside the observed foreground band. This is not a server-side
+speedup claim; it removes a browser scheduling artifact.
+
+All four runs produced 10,020 table rows, 9,470 filtered rows, 4,620 BOM roots/groups, status counts
+`OK=8565`, `Period Shortage=47`, `Shortage=1408`, the same two known warning codes
+(`comp_demand_dropped`, `location_stock_unconfigured`), and no errors. The older anonymized pairs in
+canonical issue #276 were 34.784/389.246 seconds (about 11.2x) and 31.094/160.035 seconds (about
+5.1x); the fresh authenticated run now reproduces the mechanism without retaining a customer
+identifier.
 
 Canonical PR #277 measured readiness overhead with 30 alternating same-host pairs: baseline/candidate
 median wall time 220.358/233.825 ms, +13.467 ms (about 6.1%) per session. Its synthetic headless

--- a/references/commands.md
+++ b/references/commands.md
@@ -1,7 +1,8 @@
 # Command Reference — `cdp.py` (CDP ตรง)
 
 transport ของ skill นี้คือ **`cdp.py`** ซึ่งเป็น asset กลางของ `Teibto/teibto-dev-standards`
-(`scripts/cdp.py`). Flow runner ต้องใช้ JSONL protocol v3+; ad-hoc command ใช้ policy ปกติของ driver.
+(`scripts/cdp.py`). Flow runner ต้องใช้ JSONL protocol v3+ ที่ ready หลังทำ target ที่ pin เป็น
+foreground และยืนยัน `visibility_state=visible`; ad-hoc command ใช้ policy ปกติของ driver.
 
 ## เตรียม (ครั้งเดียวต่อเครื่อง)
 

--- a/references/flow-spec.md
+++ b/references/flow-spec.md
@@ -18,6 +18,8 @@ $env:TEIBTO_CDP_SCRIPT = 'D:\path\to\teibto-dev-standards\scripts\cdp.py'
 - secret ส่งผ่าน stdin (`--vars-json -`), ไม่อยู่ใน process argv/log/report
 - หนึ่ง run ใช้ target ที่ pin และ `cdp.py` JSONL protocol v3+ เพียง process/WebSocket เดียว;
   runner ขอ `--input-settle=none` และ verify policy จาก ready handshake แบบ fail closed
+- ready handshake ต้องยืนยัน `foreground=true` + `visibility_state=visible` ของ target ที่ pin;
+  ขาด field = `DRIVER_INCOMPATIBLE`, target ยัง hidden = `TARGET_BACKGROUND` และไม่มี step ใดเริ่ม
 - `open` รอ main-frame commit/load event จริง; ไม่ใช้ zero-drain + `readyState` ที่อาจอ่านหน้าเก่า
 - `click` ใช้ native input เท่านั้น; ไม่มี JS fallback เงียบ
 - action/wait/assert/screenshot/console ล้ม = หยุด scenario และ verdict `FAIL`
@@ -94,6 +96,12 @@ Dialog: cdp.py protocol v3 แนบ `dialogs: [{type,message,answer}]` ใน r
 default `safe` (alert = accept, อย่างอื่น = dismiss) และเปลี่ยนได้เฉพาะ `--dialog` ของ runner —
 QA run ไม่ inherit `DIALOG` จาก shell ตาม SKILL.md invariant 5. ทุก dialog จึงผูกกับ step/command
 ที่ทำให้เกิดได้โดยตรง; payload ที่ shape ผิดทำให้ `INVALID_SESSION_OUTPUT` แทนการทิ้ง evidence เงียบ ๆ.
+
+ก่อน emit `ready`, canonical driver ทำ target ที่ pin เป็น foreground และพิสูจน์
+`document.visibilityState=visible`. Runner ไม่เรียก screenshot เพื่อ activate แบบอ้อมและไม่ยอมรับ
+run ที่ target hidden เพราะ Chrome อาจ throttle timer ของ NetSuite จน performance baseline ช้าปลอม.
+`run_start.driver_policy.foreground_required` และ `session_ready.foreground`/`visibility_state` เก็บ
+contract กับหลักฐานที่ใช้จริงใน artifact.
 
 `run-log.jsonl` เก็บ runner wall-clock และ authoritative driver `duration_ms`/`attempts` แยก
 `action`, `wait`, `assert`, `capture`; failure มี partial phases + `failing_phase`, console check มี

--- a/references/gotchas.md
+++ b/references/gotchas.md
@@ -23,6 +23,7 @@
 15. `innerWidth` ใต้ device-metrics override รวม scrollbar — ด่าน overflow จึงแดงทุกความกว้าง (fail ปลอม)
 16. `el.focus()` ไม่ทำให้ `:focus-visible` ทำงาน — ด่าน focus ring รายงานว่า "ทุกปุ่มไม่มี ring"
 17. Chrome cache หน้าเดิม — แก้ไฟล์แล้ว QA ยังวัดโค้ดเก่า ผลที่ได้จึงเป็นของรุ่นก่อนแก้
+18. NetSuite อยู่แท็บเบื้องหลัง — timer throttle ทำให้ performance baseline ช้าปลอมหลายเท่า
 
 ---
 
@@ -344,3 +345,17 @@ c.nav(URL + "?qa=" + str(int(time.time())))   # cache-bust ทุกรอบ
 
 ตัวชี้ขาดว่าเจอกับดักนี้: เปิด URL พร้อม query ใหม่แล้วผลเปลี่ยนทันที · เจอจริง 2026-08-15
 (#117 ของ ERP-AI-First) เสียเวลาไปหนึ่งรอบเต็มกับการยืนยันว่า fix ที่ถูกอยู่แล้ว "ไม่ทำงาน"
+
+---
+
+## 18. NetSuite อยู่แท็บเบื้องหลัง — performance baseline ช้าปลอมหลายเท่า [HIGH]
+
+NetSuite client loop ที่ yield ด้วย `setTimeout(0)` ถูก Chrome throttle เมื่อ
+`document.visibilityState=hidden`. คำสั่งยังสำเร็จและผลธุรกิจอาจเหมือนเดิม แต่เวลารวมพองขึ้นหลายเท่า;
+การสรุปว่า Suitelet/MRP ช้าจาก run นี้จึงผิด.
+
+ก่อน `session_ready`, canonical driver ต้องเรียก `Page.bringToFront` กับ **target ที่ pin** และยืนยัน
+`document.visibilityState=visible`. Runner ต้องเห็น `foreground=true` กับ
+`visibility_state=visible` จึงเริ่ม step; ขาด field ให้ถือว่า driver ไม่ compatible และ hidden ให้ fail
+`TARGET_BACKGROUND`. อย่าใช้ screenshot เพื่อปลุกแท็บ เพราะ performance pass ที่ไม่ถ่ายภาพจะย้อนกลับ
+ไปช้าโดยไม่มีสัญญาณเตือน.

--- a/references/perf-layer.md
+++ b/references/perf-layer.md
@@ -64,16 +64,19 @@ AB eval "performance.mark('qa_end');performance.measure('qa_action','qa_start','
 
 สำหรับ Suitelet/non-record page ให้ลด overhead โดยยังเก็บหลักฐานที่เชื่อได้:
 
-1. ใช้ persistent `--user-data-dir` เพื่อเก็บ login/trusted-device token แต่แยกหนึ่ง profile + port
+1. ใช้ runner/driver ที่ ready เฉพาะหลัง target ที่ pin เป็น foreground และ
+   `document.visibilityState=visible`; ห้ามใช้การถ่าย screenshot เป็น activation side effect และห้าม
+   รับ run ที่ hidden เป็น baseline เพราะ Chrome throttle timer ของ NetSuite ได้.
+2. ใช้ persistent `--user-data-dir` เพื่อเก็บ login/trusted-device token แต่แยกหนึ่ง profile + port
    ต่อ job; ห้ามรันขนานด้วย profile เดียวเพราะ cookie/session ชนกัน.
-2. รวม scenarios ที่เกี่ยวข้องไว้ใน flow เดียว เพื่อ reuse `cdp.py session --jsonl` process/WebSocket
+3. รวม scenarios ที่เกี่ยวข้องไว้ใน flow เดียว เพื่อ reuse `cdp.py session --jsonl` process/WebSocket
    เดียว; อย่าเรียก driver process ใหม่ทุก step.
-3. ใช้ page-specific observable `wait: "fn:..."`; หลีกเลี่ยง fixed sleep และชื่อ compatibility
+4. ใช้ page-specific observable `wait: "fn:..."`; หลีกเลี่ยง fixed sleep และชื่อ compatibility
    `networkidle` เมื่อผลที่ต้องการเป็น AJAX/Oracle JET state.
-4. ใช้ `doc: false` ใน performance/adversarial pass และไม่ต้องใส่ `capture:false`: step ที่ผ่านจะไม่ถ่าย
+5. ใช้ `doc: false` ใน performance/adversarial pass และไม่ต้องใส่ `capture:false`: step ที่ผ่านจะไม่ถ่าย
    แต่ failure ยังได้ screenshot อัตโนมัติ.
-5. รัน agent ด้วย `--stdout summary`; JSONL เต็มยังอยู่ใน artifact โดยไม่ไหลเข้า context.
-6. ใช้ selector/get/count แบบแคบ; ห้าม whole-page HTML หรือ a11y dump.
+6. รัน agent ด้วย `--stdout summary`; JSONL เต็มยังอยู่ใน artifact โดยไม่ไหลเข้า context.
+7. ใช้ selector/get/count แบบแคบ; ห้าม whole-page HTML หรือ a11y dump.
 
 ตัวอย่าง:
 

--- a/references/reliability-policy.md
+++ b/references/reliability-policy.md
@@ -17,6 +17,10 @@ infra error = ปัญหา transport/CDP หลุด ไม่เกี่�
 | `WS_DISCONNECTED` / `WS_ERROR` | WebSocket หลุดกลาง flow | cdp.py session protocol |
 | `CONTEXT_DESTROYED` | navigation ทำให้ execution context เปลี่ยน | retry 1 ครั้งเฉพาะ safe read ใน cdp.py |
 
+`DRIVER_INCOMPATIBLE` และ `TARGET_BACKGROUND` ก่อนเริ่ม flow ไม่ใช่เหตุให้ยิง scenario ซ้ำจนผ่าน:
+อัปเดต canonical driver หรือแก้ Chrome/target ownership แล้วเริ่ม run ใหม่. ห้ามลด contract หรือใช้
+run ที่ hidden เป็น performance evidence.
+
 `flow-runner.py` ไม่ replay action เอง: transport error ทำให้ run ปัจจุบัน FAIL และปิด bounded child
 process. การ retry ทั้ง scenario ต้องเป็นการตัดสินใจของ orchestration ภายนอกหลังตรวจสาเหตุแล้ว
 เท่านั้น เพื่อไม่กด action ที่เปลี่ยน state ซ้ำโดยไม่รู้ตัว

--- a/scripts/flow-runner.py
+++ b/scripts/flow-runner.py
@@ -238,6 +238,22 @@ class CDPSession:
         if ready.get("target_id") != target_id:
             self.close(force=True)
             raise RunnerError("TARGET_MISMATCH", f"CDP ต่อผิด target (driver: {script})", detail=ready)
+        if "foreground" not in ready or "visibility_state" not in ready:
+            self.close(force=True)
+            raise RunnerError(
+                "DRIVER_INCOMPATIBLE",
+                "cdp.py ไม่มี foreground-ready evidence: runner ต้องได้ foreground=true "
+                f"และ visibility_state=visible ก่อนเริ่มวัด performance (driver: {script})",
+                detail=ready,
+            )
+        if ready.get("foreground") is not True or ready.get("visibility_state") != "visible":
+            self.close(force=True)
+            raise RunnerError(
+                "TARGET_BACKGROUND",
+                "pinned target ไม่ได้อยู่ foreground/visible; ห้ามใช้ run นี้เป็น performance "
+                f"baseline (driver: {script})",
+                detail=ready,
+            )
         self.ready = ready
 
     def _read_stdout(self) -> None:
@@ -581,6 +597,8 @@ def run_flow(flow: dict[str, Any], path: Path, output_dir: Path, variables: dict
                "driver_policy": {"protocol": SESSION_PROTOCOL,
                                  "min_version": MIN_SESSION_VERSION,
                                  "input_settle": INPUT_SETTLE_POLICY,
+                                 "foreground_required": True,
+                                 "visibility_state": "visible",
                                  "dialog": dialog,
                                  "dialog_evidence": "structured-per-command",
                                  "navigation": "event-bound-load"},
@@ -596,6 +614,8 @@ def run_flow(flow: dict[str, Any], path: Path, output_dir: Path, variables: dict
                    "protocol": session.ready.get("protocol"),
                    "version": session.ready.get("version"),
                    "input_settle": session.ready.get("input_settle"),
+                   "foreground": session.ready.get("foreground"),
+                   "visibility_state": session.ready.get("visibility_state"),
                    "port": session.ready.get("port"), "duration_ms": startup_ms})
         global_index = 0
         for scenario in flow["scenarios"]:

--- a/tests/fixtures/fake_cdp.py
+++ b/tests/fixtures/fake_cdp.py
@@ -19,9 +19,13 @@ if os.environ.get("FAKE_CDP_REJECT_INPUT_SETTLE") and input_settle != "fixed":
                                 "message": f"session: flag ไม่รู้จัก: --input-settle={input_settle}",
                                 "transient": False}}), flush=True)
     raise SystemExit(2)
-print(json.dumps({"type": "ready", "ok": True, "protocol": "teibto-cdp-jsonl",
-                  "version": int(os.environ.get("FAKE_CDP_VERSION", "3")),
-                  "input_settle": input_settle, "target_id": target, "port": 9222}), flush=True)
+ready = {"type": "ready", "ok": True, "protocol": "teibto-cdp-jsonl",
+         "version": int(os.environ.get("FAKE_CDP_VERSION", "3")),
+         "input_settle": input_settle, "target_id": target, "port": 9222}
+if not os.environ.get("FAKE_CDP_OMIT_FOREGROUND"):
+    ready["foreground"] = os.environ.get("FAKE_CDP_FOREGROUND", "true").lower() == "true"
+    ready["visibility_state"] = os.environ.get("FAKE_CDP_VISIBILITY", "visible")
+print(json.dumps(ready), flush=True)
 values = {}
 url = "about:blank"
 # FAKE_CDP_DIALOG=<kind>:<message> makes every click raise that dialog; the answer follows the

--- a/tests/test-flow-runner-live.sh
+++ b/tests/test-flow-runner-live.sh
@@ -60,11 +60,21 @@ for _ in $(seq 1 20); do
 done
 
 TARGET_ID="$("${PY}" "${CDP}" newtab "http://127.0.0.1:${HTTP_PORT}/live-page.html?job=runner-live")"
+COMPETING_ID="$(TGT_ID="${TARGET_ID}" "${PY}" "${CDP}" newtab "about:blank#runner-competing")"
 VARS="$(printf '{"base_url":"http://127.0.0.1:%s/live-page.html","tester":"s3cret-Ada"}' "${HTTP_PORT}")"
 LIVE_RUNS="${LIVE_RUNS:-1}"
 [[ "${LIVE_RUNS}" =~ ^[0-9]+$ ]] && [ "${LIVE_RUNS}" -ge 1 ] && [ "${LIVE_RUNS}" -le 50 ] \
   || { echo "FAIL: LIVE_RUNS must be an integer in 1..50"; exit 2; }
 for run in $(seq 1 "${LIVE_RUNS}"); do
+  # Make the owned target hidden before every run. Session readiness must foreground the exact
+  # pinned target; otherwise Chrome background-timer throttling invalidates performance evidence.
+  curl -sf "http://127.0.0.1:${CDP_PORT}/json/activate/${COMPETING_ID}" >/dev/null
+  TARGET_BEFORE="$(TGT_ID="${TARGET_ID}" "${PY}" "${CDP}" eval "document.visibilityState")"
+  COMPETING_BEFORE="$(TGT_ID="${COMPETING_ID}" "${PY}" "${CDP}" eval "document.visibilityState")"
+  [ "${TARGET_BEFORE}" = "hidden" ] && [ "${COMPETING_BEFORE}" = "visible" ] || {
+    echo "FAIL: foreground precondition target=${TARGET_BEFORE} competing=${COMPETING_BEFORE}"
+    exit 1
+  }
   # Print terminal output and the full artifact on failure: cleanup removes ${WORK}, so a silent
   # exit would hide the cause (for example DRIVER_INCOMPATIBLE from a stale cdp.py).
   printf '%s' "${VARS}" | "${PY}" "${ROOT}/scripts/flow-runner.py" \
@@ -77,23 +87,38 @@ for run in $(seq 1 "${LIVE_RUNS}"); do
     [ ! -f "${WORK}/out-${run}/run-log.jsonl" ] || cat "${WORK}/out-${run}/run-log.jsonl"
     exit 1
   }
+  TARGET_AFTER="$(TGT_ID="${TARGET_ID}" "${PY}" "${CDP}" eval "document.visibilityState")"
+  COMPETING_AFTER="$(TGT_ID="${COMPETING_ID}" "${PY}" "${CDP}" eval "document.visibilityState")"
+  [ "${TARGET_AFTER}" = "visible" ] && [ "${COMPETING_AFTER}" = "hidden" ] || {
+    echo "FAIL: runner did not foreground pinned target target=${TARGET_AFTER} competing=${COMPETING_AFTER}"
+    exit 1
+  }
 done
 
 grep -q 'event.isTrusted' "${ROOT}/tests/fixtures/live-page.html"
 [ -s "${WORK}/out-1/shots/native-click-03.png" ]
 "${PY}" - "${WORK}" "${LIVE_RUNS}" <<'PY'
 import json
+import math
 import statistics
 import sys
 from pathlib import Path
 
 work, count = Path(sys.argv[1]), int(sys.argv[2])
 rows = []
+
+
+def p95(values):
+    ordered = sorted(values)
+    return ordered[max(0, math.ceil(0.95 * len(ordered)) - 1)]
+
+
 for run in range(1, count + 1):
     events = [json.loads(line) for line in
               (work / f"out-{run}" / "run-log.jsonl").read_text(encoding="utf-8").splitlines()]
     ready = next(item for item in events if item["type"] == "session_ready")
     assert ready["version"] >= 3 and ready["input_settle"] == "none", ready
+    assert ready["foreground"] is True and ready["visibility_state"] == "visible", ready
     steps = [item for item in events if item["type"] == "step_done"]
     assert len(steps) == 3 and all(item["status"] != "fail" for item in steps), steps
     fill = steps[1]["timings"]["phases"]
@@ -126,8 +151,10 @@ for run in range(1, count + 1):
                  "run_total_ms": done["duration_ms"]})
 print(json.dumps({"runs": count, "failures": 0,
                   "median_ms": {key: round(statistics.median(row[key] for row in rows), 3)
-                                for key in rows[0]}}, separators=(",", ":")))
+                                for key in rows[0]},
+                  "p95_ms": {key: round(p95([row[key] for row in rows]), 3)
+                             for key in rows[0]}}, separators=(",", ":")))
 PY
 if grep -R -q 's3cret-Ada' "${WORK}"/out-*/run-log.jsonl; then exit 1; fi
 if grep -R -q 's3cret-Ada' "${WORK}"/out-*/qa-report.md; then exit 1; fi
-echo "PASS: ${LIVE_RUNS} real-Chrome run(s) used protocol v3, per-step dialogs, event-bound nav, fast native input, async waits, performance budgets, summary stdout, redaction, telemetry, and artifacts"
+echo "PASS: ${LIVE_RUNS} real-Chrome run(s) foregrounded the exact pinned target and used protocol v3, per-step dialogs, event-bound nav, fast native input, async waits, performance budgets, summary stdout, redaction, telemetry, and artifacts"

--- a/tests/test_flow_runner.py
+++ b/tests/test_flow_runner.py
@@ -80,6 +80,8 @@ class FlowRunnerTests(unittest.TestCase):
         ready = next(item for item in payloads if item["type"] == "session_ready")
         self.assertEqual(3, ready["version"])
         self.assertEqual("none", ready["input_settle"])
+        self.assertIs(True, ready["foreground"])
+        self.assertEqual("visible", ready["visibility_state"])
         self.assertEqual(str(FAKE_CDP), ready["cdp_script"])
         self.assertGreaterEqual(ready["duration_ms"], 0)
         steps = [item for item in payloads if item["type"] == "step_done"]
@@ -286,6 +288,41 @@ class FlowRunnerTests(unittest.TestCase):
         self.assertEqual(1, process.returncode)
         self.assertIn("DRIVER_INCOMPATIBLE",
                       (out / "run-log.jsonl").read_text(encoding="utf-8"))
+
+    def test_driver_without_foreground_evidence_is_rejected_as_incompatible(self):
+        process, out, _ = self.run_flow("""
+            story: missing-foreground
+            title: Missing foreground evidence
+            scenarios:
+              - id: smoke
+                steps:
+                  - {action: open, target: "https://example.test", capture: false}
+        """, env_overrides={"FAKE_CDP_OMIT_FOREGROUND": "1"})
+        self.assertEqual(1, process.returncode)
+        payloads = [json.loads(line) for line in
+                    (out / "run-log.jsonl").read_text(encoding="utf-8").splitlines()]
+        fatal = next(item for item in payloads if item["type"] == "fatal")
+        self.assertEqual("DRIVER_INCOMPATIBLE", fatal["error"]["code"])
+        self.assertIn("foreground-ready evidence", fatal["error"]["message"])
+        self.assertIn(str(FAKE_CDP), fatal["error"]["message"])
+
+    def test_hidden_target_fails_closed_before_any_flow_step(self):
+        process, out, _ = self.run_flow("""
+            story: hidden-target
+            title: Hidden target
+            scenarios:
+              - id: smoke
+                steps:
+                  - {action: open, target: "https://example.test", capture: false}
+        """, env_overrides={"FAKE_CDP_FOREGROUND": "false",
+                             "FAKE_CDP_VISIBILITY": "hidden"})
+        self.assertEqual(1, process.returncode)
+        payloads = [json.loads(line) for line in
+                    (out / "run-log.jsonl").read_text(encoding="utf-8").splitlines()]
+        fatal = next(item for item in payloads if item["type"] == "fatal")
+        self.assertEqual("TARGET_BACKGROUND", fatal["error"]["code"])
+        self.assertFalse(any(item["type"] == "step" for item in payloads))
+        self.assertIn("performance baseline", fatal["error"]["message"])
 
     def test_auto_answered_dialogs_are_evidence_and_policy_is_pinned(self):
         flow = """


### PR DESCRIPTION
## Summary

- require canonical protocol-v3 ready evidence that the exact pinned target is foreground and visible before any flow step
- fail closed as DRIVER_INCOMPATIBLE for missing evidence and TARGET_BACKGROUND for a hidden target
- re-hide the target behind a competing tab before every real-Chrome compatibility run, then verify the runner foregrounds the correct tab
- document the NetSuite background-timer risk, immutable upstream candidate pin, and measured median/p95 evidence

## Fresh authenticated NetSuite evidence

- same SB2 MRP inputs with last-run/BOM caches explicitly invalidated before each run
- cold/warm foreground runs: 55.529 s / 34.664 s
- background/recovery run: 644.391 s total; hidden after 0.683 s, still incomplete after the bounded 600-second wait, foregrounded after 617.747 s, then completed about 26.6 s later
- issue #74 runner plus PR #277 driver: target hidden before session, ready foreground, visible throughout MRP, completed in 31.310 s; 95.1% lower elapsed than background/recovery
- all runs returned the same 10,020 rows, 9,470 filtered rows, 4,620 BOM roots/groups, status counts, two known warning codes, and no errors

The slow run did not complete while hidden, so this is reported as removal of a browser scheduling artifact rather than a server-side speedup. The flow used read-only planning actions and did not submit Create PR/PO/WO or mutate production data.

## Verification

- py -m unittest discover -s tests -v: 29 passed
- py scripts/validate-skill.py: PASS
- node --check app/server.js: PASS
- py scripts/build-skill.py: 27-entry bundle built
- bash -n tests/test-flow-runner-live.sh: PASS
- final real-Chrome compatibility set: 20/20 PASS; median/p95 step flow 653.229/739.154 ms; median/p95 total 972.063/1,198.926 ms
- preceding real-Chrome set: 20/20 PASS; median step flow 675.275 ms
- canonical smoke suite: 41 passed, 0 failed
- gitleaks history scan: PASS

## Upstream dependency / Draft gate

CI is intentionally pinned to immutable teibto-dev-standards candidate 56b4e788ab80807c3f62b43b88a151a52a96df8e from Teibto/teibto-dev-standards#276 / Teibto/teibto-dev-standards#277. Keep this PR Draft until that change receives second-party review, its upstream release dependency Teibto/teibto-dev-standards#274 / Teibto/teibto-dev-standards#275 clears the GitHub billing-blocked Windows job, and a reviewed release tag exists. Before Ready, replace the SHA with that tag and rerun unit, live Chrome, and smoke gates.

No browser or driver release/tag is created by this PR.

Fixes #74