### PR TITLE
docs: put refs first and make pixel-only results a separate verdict (#78)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@
 
 ### Added
 
+- ลำดับการเล็งเป้าแบบ semantic-first เป็นกติกาใน `SKILL.md` + `references/commands.md`:
+  `@ref` จาก `a11y` → `data-test`/`id` → CSS เชิงโครงสร้าง → พิกัด (canvas/วิดีโอ/surface ที่ฝังมาเท่านั้น
+  และ `cdp.py` ไม่มีคำสั่งที่รับพิกัดอยู่แล้ว จึงเป็นข้อจำกัดที่บันทึกไว้ ไม่ใช่ fallback) (#78)
+- `references/cdp-limits.md` §0 นิยาม **`PASS(visual)`** เป็นผลคนละชั้นกับ `PASS` และเพิ่มคอลัมน์
+  **ชั้นหลักฐานสูงสุด** ให้ตารางข้อจำกัด — เดิมตารางบอกแค่ว่าทำอะไรไม่ได้ ไม่ได้บอกว่าเส้นทางที่เหลือ
+  ให้ผลแข็งแค่ไหน คนอ่านจึงยกผลจาก `PASS(visual)` ขึ้นเป็น `PASS` ได้โดยไม่มีอะไรทัดทาน (#78)
+- ด่าน `targeting_violations()` ใน `scripts/validate-skill.py`: ล้มเมื่อ `SKILL.md` ไม่ระบุลำดับการเล็งเป้า
+  หรือขาดชั้นใดชั้นหนึ่ง, เมื่อ `cdp-limits.md` ทิ้งนิยาม `PASS(visual)`, และเมื่อเอกสารใดสอนสูตรคลิกด้วยพิกัด
+  โดย **ยังปล่อยผ่านข้อความที่แค่ *อธิบาย* ข้อจำกัดเรื่องพิกัด** (เช่น `elementFromPoint` ใน `gotchas.md` §8)
+  — ถ้าจับกว้างกว่านี้ เอกสารที่ซื่อสัตย์จะกลายเป็นตัวที่ทำให้ CI แดง (#78)
+
 - `docs/BROWSER-AGENT-STANDARD.md` — Browser Agent Standard (BAS) v1 เป็น **ข้อเสนอ**: pain inventory
   26 ข้อจากบันทึกจริงของ repo (17 gotchas + CHANGELOG + claims ledger), กฎ BAS-1 ถึง BAS-9,
   coverage matrix ที่บอกว่ากฎข้อไหนปิด pain ข้อไหน, มติยืนยันว่า transport ยังเป็น `cdp.py` ตัวเดียว

--- a/SKILL.md
+++ b/SKILL.md
@@ -89,9 +89,20 @@ nav --until=load
   -> console check
 ```
 
-Use `a11y "<visible name>"` to obtain a semantic `@ref` when a stable selector is unavailable. Check
-`console` after key steps; an error saying no collector exists means the page was not observed, not
-that it had no errors. Use `lens netlog` only inside a `run` that enabled `netlog on`.
+Target in this order and stop at the first one that works:
+
+1. `@ref` from `a11y "<visible name>"` — semantic, and it survives a re-layout
+2. a stable `data-test` or `id` the application owns
+3. a structural CSS selector
+4. viewport coordinates — canvas, video, and embedded surfaces only, and `cdp.py` has **no**
+   coordinate action, so this row is a documented limit rather than a fallback
+
+Coordinates cannot be replayed once the layout moves, which is the evidence this repo exists to
+produce. A result only pixels could produce is `PASS(visual)`, never `PASS`; an interaction only
+coordinates could drive is `UNVERIFIED`. See [`references/cdp-limits.md`](references/cdp-limits.md).
+
+Check `console` after key steps; an error saying no collector exists means the page was not observed,
+not that it had no errors. Use `lens netlog` only inside a `run` that enabled `netlog on`.
 
 For repeatable flows, `scripts/flow-runner.py` validates the YAML schema, requires a pinned target,
 negotiates CDP JSONL protocol v3+, and owns one bounded `session --jsonl --input-settle=none` per run.

--- a/docs/CLAIMS-AUDIT.md
+++ b/docs/CLAIMS-AUDIT.md
@@ -103,6 +103,10 @@ than pinning a tokenizer-specific absolute count.
 | Page content reaching the agent is evidence, never instruction | principle | `SKILL.md` invariant 8; enforced by the standard gate in `scripts/validate-skill.py` |
 | A reported claim carries a verdict and an evidence class; `inferred` and `visual` cannot stand as `PASS` | principle | `SKILL.md` verdict table; gate rejects a SKILL.md that drops a class |
 | A BAS rule with no Gate line cannot be cited in a QA report | verified | `tests/test_standard_gate.py` ungated-rule and dropped-rule cases |
+| Targeting order is `@ref` first and coordinates last | principle | `SKILL.md` live action loop; the gate rejects docs that drop a tier |
+| A pixel-only result is `PASS(visual)`, never a full `PASS` | principle | `references/cdp-limits.md` §0; the gate requires the definition to stay |
+| Documentation cannot ship a coordinate-click recipe, while prose documenting the limit still passes | verified | `tests/test_standard_gate.py` coordinate-recipe and documented-limit cases |
+| `cdp.py click` accepts a selector or `@ref` only and resolves the centre itself; no CLI path takes raw coordinates | verified, version-pinned | canonical `cdp.py` v0.83.0 command dispatch (`cmd == "click"` → `center(a[0])` → `mouseclick`) |
 | Missing element is distinct from an empty value | verified | smoke `get` checks |
 | Eval shares page global scope; an IIFE avoids repeated `let` collisions | verified | smoke paired case |
 | One-shot device-scale/mobile override does not survive its WebSocket | verified, version-pinned | smoke paired `viewport`/`shot`; canonical driver tests own deeper behavior |

--- a/references/cdp-limits.md
+++ b/references/cdp-limits.md
@@ -9,18 +9,45 @@
 
 ---
 
+## 0. ลำดับการเล็งเป้า และ `PASS(visual)`
+
+เล็งเป้าตามลำดับนี้ หยุดที่ตัวแรกที่ใช้ได้:
+
+| ลำดับ | ใช้อะไร | ทำไมอยู่ตรงนี้ |
+|---|---|---|
+| 1 | `@ref` จาก `a11y "<ชื่อที่มองเห็น>"` | semantic · ทน re-layout · ราคาถูกที่สุดต่อการค้นหนึ่งครั้ง |
+| 2 | `data-test` / `id` ที่แอปเป็นเจ้าของ | นิ่งพอ ๆ กัน แต่ผูกกับ implementation |
+| 3 | CSS selector เชิงโครงสร้าง | ใช้ได้ แต่เปราะต่อการ re-render → ต้องยืนยัน identity ที่กำลังจะคลิก |
+| 4 | พิกัดใน viewport | **canvas · วิดีโอ · surface ที่ฝังมา เท่านั้น** |
+
+**`PASS(visual)` คือผลคนละชั้นกับ `PASS`** — ใช้เมื่อสิ่งเดียวที่ยืนยันผลได้คือ pixel: ภาพหน้าจอ,
+`diff`, เนื้อหาใน canvas, หน้าที่อ่านค่าจาก DOM ไม่ได้. ห้ามนับเป็น `PASS` เต็ม เพราะ:
+
+- **replay ไม่ได้** — "คลิกที่ (412,233)" ตายทันทีที่ layout ขยับ ในขณะที่ `@ref`/selector ใส่
+  `flow.yaml` แล้วรันซ้ำได้ · หลักฐานที่ replay ไม่ได้คือหลักฐานที่ตรวจซ้ำไม่ได้
+- **ตัวเลขไม่ได้บอกว่าถูก** — `diff` บอกว่า "ต่างกี่ pixel" ไม่ได้บอกว่า "ผลลัพธ์ทางธุรกิจถูกไหม"
+
+ยกระดับจาก `PASS(visual)` เป็น `PASS` ได้ด้วยการหา assertion ที่อ่านจาก DOM/API มายืนยันเรื่องเดียวกัน
+ถ้าหาไม่ได้ ให้รายงานตามจริงว่าอยู่ชั้นนี้ พร้อมบอกว่าอะไรจะทำให้ยกระดับได้
+
+---
+
 ## 1. สิ่งที่ CDP แตะไม่ได้
 
-| ทำไม่ได้ | ทำไม | ต้องทำแทน |
-|---|---|---|
-| screenshot ของ `alert` / `confirm` / file dialog | เป็น native UI นอก DOM ทั้งหมด | OS-level capture (สูตรใน skill `netsuite-ui-qa-testing`) · ถ้าไม่ได้ทำ **ห้ามอ้างว่ามีภาพ** |
-| screenshot ของ native `<select>` popup ที่กางอยู่ | popup เป็น layer นอก DOM บางรุ่นจับติดบางรุ่นไม่ติด | ท่า DOM `size=N` (`commands.md` §จับภาพ native `<select>`) — อยู่ใน DOM จึงจับติดทุกรุ่น |
-| element-scoped `shot` ที่ต้องมี top-layer popup ติดมาด้วย | `<dialog>`/tooltip ที่ portal ออกไปอยู่คนละ layer | ถ่ายทั้ง viewport แล้ว crop ทีหลัง (`gotchas.md` §5) |
-| สคริปต์หน้า `chrome://*` และ Chrome PDF viewer | สิทธิ์ของ renderer คนละชั้น | ตรวจ PDF **จากไฟล์** ไม่ใช่จากหน้าจอ (`pdf-reports.md`) |
-| ตอบ dialog ที่เกิด**ก่อน** เราต่อ CDP | ไม่มีใครฟัง event ตอนนั้น | เปิดแท็บของตัวเองด้วย `newtab` แล้วค่อยทำงาน (golden rule #1) |
-| ยืนยันว่า `setfile` แนบไฟล์สำเร็จผ่าน `input.files.length` | `DOM.setFileInputFiles` ใส่สำเร็จแต่ page JS เห็น 0 | ดู **ชื่อไฟล์ที่โผล่ใน UI** เป็นสัญญาณจริง (`cdp.md` ของ `netsuite-qa-browser`) |
-| วัด contrast ของสี | lens `theme` เทียบสีแบบตรงตัวเท่านั้น | axe-core ผ่าน `a11y-layer.md` |
-| จำลอง input ของ touch/gesture หลายนิ้ว | `Input` domain ครอบเท่าที่ `cdp.py` ใช้อยู่ | ยังไม่รองรับ — อย่ารายงานว่าเทสแล้ว |
+คอลัมน์สุดท้ายคือ **ชั้นหลักฐานที่สูงที่สุดที่เส้นทางนั้นให้ได้** — ไม่ใช่สิ่งที่หวังไว้
+
+| ทำไม่ได้ | ทำไม | ต้องทำแทน | ชั้นสูงสุด |
+|---|---|---|---|
+| screenshot ของ `alert` / `confirm` / file dialog | เป็น native UI นอก DOM ทั้งหมด | OS-level capture (สูตรใน skill `netsuite-ui-qa-testing`) · ถ้าไม่ได้ทำ **ห้ามอ้างว่ามีภาพ** | `UNVERIFIED` |
+| screenshot ของ native `<select>` popup ที่กางอยู่ | popup เป็น layer นอก DOM บางรุ่นจับติดบางรุ่นไม่ติด | ท่า DOM `size=N` (`commands.md` §จับภาพ native `<select>`) — อยู่ใน DOM จึงจับติดทุกรุ่น | `PASS(visual)` |
+| element-scoped `shot` ที่ต้องมี top-layer popup ติดมาด้วย | `<dialog>`/tooltip ที่ portal ออกไปอยู่คนละ layer | ถ่ายทั้ง viewport แล้ว crop ทีหลัง (`gotchas.md` §5) | `PASS(visual)` |
+| สคริปต์หน้า `chrome://*` และ Chrome PDF viewer | สิทธิ์ของ renderer คนละชั้น | ตรวจ PDF **จากไฟล์** ไม่ใช่จากหน้าจอ (`pdf-reports.md`) | `verified` เมื่อตรวจจากไฟล์ · `UNVERIFIED` เมื่อดูจากหน้าจอ |
+| ตอบ dialog ที่เกิด**ก่อน** เราต่อ CDP | ไม่มีใครฟัง event ตอนนั้น | เปิดแท็บของตัวเองด้วย `newtab` แล้วค่อยทำงาน (golden rule #1) | `UNVERIFIED` |
+| ยืนยันว่า `setfile` แนบไฟล์สำเร็จผ่าน `input.files.length` | `DOM.setFileInputFiles` ใส่สำเร็จแต่ page JS เห็น 0 | ดู **ชื่อไฟล์ที่โผล่ใน UI** เป็นสัญญาณจริง (`cdp.md` ของ `netsuite-qa-browser`) | `verified` ผ่าน UI · ห้ามอ้างจาก `files.length` |
+| วัด contrast ของสี | lens `theme` เทียบสีแบบตรงตัวเท่านั้น | axe-core ผ่าน `a11y-layer.md` | `measured` ผ่าน axe · `inferred` จาก lens |
+| จำลอง input ของ touch/gesture หลายนิ้ว | `Input` domain ครอบเท่าที่ `cdp.py` ใช้อยู่ | ยังไม่รองรับ — อย่ารายงานว่าเทสแล้ว | `UNVERIFIED` |
+| อ่านเนื้อหาใน `<canvas>` / วิดีโอ / surface ที่ฝังมา | ไม่มี DOM ให้ query | ภาพเป็นทางเดียว | `PASS(visual)` |
+| **คลิกที่พิกัดด้วย trusted input** | `cdp.py` ไม่มีคำสั่งที่รับพิกัด · ยิงเองผ่าน `eval` ได้แต่เป็น synthetic event ซึ่ง invariant 2 ห้ามใช้เป็น fallback | ยังไม่รองรับ — ถ้าฟีเจอร์ต้องการจริงให้เปิด issue ที่ `teibto-dev-standards` (§4) | `UNVERIFIED` |
 
 ## 2. สิ่งที่ CDP ทำได้ แต่ **ไม่ควรใช้ browser ทำ**
 

--- a/references/commands.md
+++ b/references/commands.md
@@ -62,6 +62,10 @@ fallback ของ action เพราะ synthetic click จะซ่อนป�
 
 ## หา element แบบ semantic (ทน dynamic UI)
 
+**ลำดับการเล็งเป้า — หยุดที่ตัวแรกที่ใช้ได้:** `@ref` จาก `a11y` → `data-test`/`id` ที่แอปเป็นเจ้าของ →
+CSS เชิงโครงสร้าง → พิกัด (canvas/วิดีโอ/surface ที่ฝังมาเท่านั้น และ **`cdp.py` ไม่มีคำสั่งที่รับพิกัด**)
+ผลที่มีแต่ pixel ยืนยันได้คือ `PASS(visual)` ไม่ใช่ `PASS` → `cdp-limits.md` §0
+
 `a11y` คืน role + accessible name + ref สำหรับค้น element แบบ semantic:
 
 ```bash

--- a/scripts/validate-skill.py
+++ b/scripts/validate-skill.py
@@ -34,6 +34,14 @@ PROPOSAL_STATUS = "สถานะ: ข้อเสนอ"
 EXPECTED_BAS_RULES = 9
 BAS_SPLIT_RE = re.compile(r"(?m)^### (?=BAS-)")
 
+TARGETING_ORDER_MARKER = "Target in this order"
+TARGETING_TIERS = ('a11y "<visible name>"', "data-test", "coordinates")
+VISUAL_VERDICT = "`PASS(visual)`"
+# A recipe, not a mention: `AB click 412 233` / `cdp.py click 412 233`. The descriptive
+# `elementFromPoint` note in gotchas.md is a limit being documented, not an instruction to follow,
+# so matching bare words here would fail the gate on honest prose.
+COORDINATE_CLICK_RE = re.compile(r"(?:\bAB|cdp\.py)\s+click\s+[\"']?-?\d")
+
 
 class ValidationError(ValueError):
     pass
@@ -148,6 +156,40 @@ def standard_violations(skill_text: str, standard_text: str) -> list[str]:
     return problems
 
 
+def targeting_violations(texts: dict[str, str]) -> list[str]:
+    """Return every way the docs break BAS-1 (semantic targeting, pixels are second class).
+
+    `texts` maps a repo-relative path to its content so the negative cases stay unit-testable.
+    """
+    problems: list[str] = []
+
+    skill_text = texts.get("SKILL.md", "")
+    if TARGETING_ORDER_MARKER not in skill_text:
+        problems.append("SKILL.md does not state the targeting order (BAS-1)")
+    missing_tiers = [tier for tier in TARGETING_TIERS if tier not in skill_text]
+    if missing_tiers:
+        problems.append("SKILL.md targeting order omits: " + ", ".join(missing_tiers))
+
+    limits_text = texts.get("references/cdp-limits.md", "")
+    if VISUAL_VERDICT not in limits_text:
+        problems.append("references/cdp-limits.md does not define PASS(visual)")
+
+    for name, text in sorted(texts.items()):
+        for match in COORDINATE_CLICK_RE.finditer(text):
+            line = text.count("\n", 0, match.start()) + 1
+            problems.append(f"{name}:{line} teaches a coordinate click; BAS-1 allows refs first")
+    return problems
+
+
+def validate_targeting() -> None:
+    texts = {"SKILL.md": (ROOT / "SKILL.md").read_text(encoding="utf-8")}
+    for path in sorted((ROOT / "references").glob("*.md")):
+        texts[f"references/{path.name}"] = path.read_text(encoding="utf-8")
+    problems = targeting_violations(texts)
+    if problems:
+        raise ValidationError("semantic targeting: " + "; ".join(problems))
+
+
 def validate_standard() -> None:
     problems = standard_violations(
         (ROOT / "SKILL.md").read_text(encoding="utf-8"),
@@ -165,12 +207,13 @@ def main() -> int:
         validate_active_names()
         validate_doc_links()
         validate_standard()
+        validate_targeting()
     except (OSError, yaml.YAMLError, ValidationError) as exc:
         print(f"FAIL: {exc}", file=sys.stderr)
         return 1
     print(
         "PASS: skill identity, active names, example flows, local Markdown links, "
-        "and browser agent standard gates"
+        "browser agent standard gates, and semantic targeting"
     )
     return 0
 

--- a/tests/test_standard_gate.py
+++ b/tests/test_standard_gate.py
@@ -75,5 +75,57 @@ class StandardGateTests(unittest.TestCase):
         )
 
 
+class SemanticTargetingGateTests(unittest.TestCase):
+    """BAS-1: refs first, pixels are a second-class verdict."""
+
+    def setUp(self) -> None:
+        self.validator = load_validator()
+        self.texts = {"SKILL.md": (ROOT / "SKILL.md").read_text(encoding="utf-8")}
+        for path in sorted((ROOT / "references").glob("*.md")):
+            self.texts[f"references/{path.name}"] = path.read_text(encoding="utf-8")
+
+    def violations(self, texts):
+        return self.validator.targeting_violations(texts)
+
+    def test_shipped_docs_pass(self) -> None:
+        self.assertEqual([], self.violations(self.texts))
+
+    def test_missing_targeting_order_fails(self) -> None:
+        texts = dict(self.texts)
+        texts["SKILL.md"] = texts["SKILL.md"].replace(
+            self.validator.TARGETING_ORDER_MARKER, "Pick whatever works"
+        )
+        self.assertIn("targeting order", " ".join(self.violations(texts)))
+
+    def test_missing_targeting_tier_fails(self) -> None:
+        texts = dict(self.texts)
+        texts["SKILL.md"] = texts["SKILL.md"].replace("data-test", "whatever")
+        self.assertIn("omits: data-test", " ".join(self.violations(texts)))
+
+    def test_missing_visual_verdict_definition_fails(self) -> None:
+        texts = dict(self.texts)
+        texts["references/cdp-limits.md"] = texts["references/cdp-limits.md"].replace(
+            self.validator.VISUAL_VERDICT, "`PASS`"
+        )
+        self.assertIn("does not define PASS(visual)", " ".join(self.violations(texts)))
+
+    def test_coordinate_click_recipe_fails(self) -> None:
+        texts = dict(self.texts)
+        texts["references/commands.md"] += '\n```bash\nAB click 412 233\n```\n'
+        message = " ".join(self.violations(texts))
+        self.assertIn("teaches a coordinate click", message)
+        self.assertIn("references/commands.md:", message)
+
+    def test_documented_limit_is_not_a_recipe(self) -> None:
+        """gotchas.md documents that elementFromPoint returns BODY inside the PDF viewer.
+
+        Prose describing a limit must not trip the gate, or the honest documentation this repo
+        depends on becomes the thing that fails CI.
+        """
+        texts = dict(self.texts)
+        texts["references/gotchas.md"] += "\n`elementFromPoint` คืน BODY และคลิกที่พิกัดไม่ทำงาน\n"
+        self.assertEqual([], self.violations(texts))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## สิ่งที่ทำ — BAS-1

### 1. ลำดับการเล็งเป้าเป็นกติกา ไม่ใช่ธรรมเนียม

เดิม `SKILL.md` เขียนว่า *"Use `a11y` to obtain a semantic `@ref` **when a stable selector is unavailable**"* ซึ่งอ่านได้ว่า `a11y` เป็น **fallback** ทั้งที่ควรเป็นตัวเลือกแรก ตอนนี้ระบุลำดับตรง ๆ:

1. `@ref` จาก `a11y "<visible name>"`
2. `data-test` / `id` ที่แอปเป็นเจ้าของ
3. CSS เชิงโครงสร้าง
4. พิกัด — canvas / วิดีโอ / surface ที่ฝังมาเท่านั้น

และบอกตรง ๆ ว่า **`cdp.py` ไม่มีคำสั่งที่รับพิกัดเลย** ชั้นที่ 4 จึงเป็นข้อจำกัดที่บันทึกไว้ ไม่ใช่ทางหนีทีไล่ ตรวจกับ canonical `v0.83.0` แล้ว: `cmd == "click"` รับ selector หรือ `@ref` แล้วหา center เอง (`center(a[0])` → `mouseclick`) ไม่มีเส้นทาง CLI ไหนรับพิกัดดิบ

### 2. `PASS(visual)` เป็นผลคนละชั้นกับ `PASS`

`references/cdp-limits.md` ได้ §0 ใหม่ที่นิยาม `PASS(visual)` พร้อมเหตุผลสองข้อว่าทำไมมันไม่ใช่ `PASS` เต็ม (replay ไม่ได้ · `diff` บอกว่าต่างกี่ pixel ไม่ได้บอกว่าผลทางธุรกิจถูกไหม) และบอกว่าจะยกระดับขึ้นเป็น `PASS` ได้ยังไง

ตารางข้อจำกัดใน §1 ได้คอลัมน์ **ชั้นสูงสุด** — เดิมตารางบอกแค่ว่า *ทำอะไรไม่ได้* กับ *ทำอะไรแทน* แต่ไม่เคยบอกว่าเส้นทางที่เหลือให้ผลแข็งแค่ไหน คนอ่านจึงยกผลที่มีแต่ภาพขึ้นเป็น `PASS` ได้โดยไม่มีอะไรทัดทาน เพิ่มสองแถวที่หายไปด้วย: อ่านเนื้อหาใน canvas (`PASS(visual)`) และคลิกที่พิกัดด้วย trusted input (`UNVERIFIED` — ยังไม่รองรับ)

### 3. ด่านที่ต้องแยก "สูตร" ออกจาก "คำอธิบาย" ให้ได้

`targeting_violations()` ใน `scripts/validate-skill.py` ล้มเมื่อ:

- `SKILL.md` ไม่ระบุลำดับ หรือขาดชั้นใดชั้นหนึ่ง
- `cdp-limits.md` ทิ้งนิยาม `PASS(visual)`
- เอกสารใดสอน **สูตร** คลิกด้วยพิกัด

ข้อสุดท้ายเป็นที่ที่ด่านแบบง่ายจะพังเงียบ: `gotchas.md` §8 บันทึกไว้ว่า `elementFromPoint` คืน BODY ในหน้า PDF viewer — เป็น **คำอธิบายข้อจำกัด** ที่รีโปนี้ต้องมี ถ้าด่านจับคำกว้าง ๆ เอกสารที่ซื่อสัตย์จะกลายเป็นตัวที่ทำให้ CI แดง `COORDINATE_CLICK_RE` จึงจับเฉพาะ *การเรียกคำสั่งพร้อมตัวเลข* และมีเทสล็อกเส้นแบ่งนี้ไว้ทั้งสองด้าน:

| เทส | ยืนยันอะไร |
|---|---|
| `test_coordinate_click_recipe_fails` | แทรก ``AB click 412 233`` แล้วต้องถูกจับ พร้อมเลขบรรทัด |
| `test_documented_limit_is_not_a_recipe` | ข้อความที่ *อธิบาย* เรื่องพิกัดต้องผ่าน |
| `test_missing_targeting_order_fails` | ถอดลำดับออกจาก `SKILL.md` |
| `test_missing_targeting_tier_fails` | ทำให้ชั้นใดชั้นหนึ่งหาย |
| `test_missing_visual_verdict_definition_fails` | ทิ้งนิยาม `PASS(visual)` |

## หลักฐาน

```
python scripts/validate-skill.py     PASS
python -m unittest discover -s tests 40 passed
bash self-test/smoke-test.sh         41 passed, 0 failed
```

## แถวใหม่ใน claims ledger

แยกชั้นตามจริง — สามแถวเป็น `principle` (กฎการรายงาน) หนึ่งแถวเป็น `verified` (เทสด้านลบพิสูจน์) และหนึ่งแถวเป็น `verified, version-pinned` (ข้อเท็จจริงเรื่อง command surface ของ `cdp.py` ที่ต้องตรวจใหม่เมื่อ bump driver)

Closes #78
Part of #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WF2vGyjyjvaRw4n6NuzmV7
