### PR TITLE
feat(runner): fail closed when a run leaves its declared origins (#79)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,24 @@
 
 ### Added
 
+- **Origin gate** — flow ประกาศ `allowed_origins` (origin เต็ม ไม่รับ wildcard) แล้ว runner ตรวจสองชั้น:
+  เป้าหมายที่ประกาศไว้ตรวจก่อนเปิดเบราว์เซอร์ และ **URL จริงหลังทุก step** เพื่อจับ redirect/SSO ที่พา run
+  ออกนอกขอบเขตหลังจากผ่านด่านแรกไปแล้ว หลุด = typed failure `ORIGIN_NOT_ALLOWED` ที่หยุด scenario
+  พร้อม failure evidence การเทียบใช้การ parse URL ไม่ใช่ prefix เพราะ
+  `https://sb1.example.com.attacker.test` ขึ้นต้นด้วย origin ที่อนุญาตเมื่อมองเป็นสตริงแต่เป็นคนละ origin
+  จริง ๆ · flow ที่ไม่ประกาศ `allowed_origins` ทำงานเหมือนเดิมและไม่จ่าย round trip เพิ่ม (#79)
+- **Risk class ระดับ step** — `risk: read | write | destructive` โดย `destructive` ต้องสั่ง
+  `--allow-destructive` ที่ระดับ run มิฉะนั้น runner ปฏิเสธ flow ตั้งแต่ก่อนเปิด session
+  (`DESTRUCTIVE_NOT_ALLOWED`) — เจตนาที่จะลบหรือทับข้อมูลจริงต้องถูกประกาศไว้ในไฟล์ ไม่ใช่ค้นพบตอนรัน (#79)
+- `run_start.run_policy` และ `run_done.origin_gate`/`risk_counts` รายงาน policy ที่ใช้จริง และ
+  `qa-report.md` ขึ้นสองบรรทัดบนหัวรายงานว่า origin ไหนถูกอนุญาต ผ่านด่านกี่ step และ destructive
+  ถูกอนุญาตหรือไม่ (#79)
+
+### Changed
+
+- `perf_budget_ms` หักเวลาที่ใช้กับ origin gate ออกจาก `outcome_ms` — budget วัดผลลัพธ์ที่สังเกตได้ของ
+  แอป ไม่ใช่ policy check ของเรา flow ที่ประกาศ origin ของตัวเองจึงไม่ถูกลงโทษด้วย budget ที่เข้มขึ้น (#79)
+
 - ลำดับการเล็งเป้าแบบ semantic-first เป็นกติกาใน `SKILL.md` + `references/commands.md`:
   `@ref` จาก `a11y` → `data-test`/`id` → CSS เชิงโครงสร้าง → พิกัด (canvas/วิดีโอ/surface ที่ฝังมาเท่านั้น
   และ `cdp.py` ไม่มีคำสั่งที่รับพิกัดอยู่แล้ว จึงเป็นข้อจำกัดที่บันทึกไว้ ไม่ใช่ fallback) (#78)

--- a/SKILL.md
+++ b/SKILL.md
@@ -111,6 +111,10 @@ action/wait timing, and emits separate action/wait/assert/capture timings. The r
 driver, an unsupported field, an assertion failure, or missing evidence.
 For agent-run flows, pass `--stdout summary`; the complete event stream remains in `run-log.jsonl`.
 Use step-level `perf_budget_ms` when action-to-observable-outcome time is an acceptance criterion.
+Declare `allowed_origins` on any flow that must not leave its environment: the runner re-checks the
+live URL after every step, so an SSO or server redirect fails as `ORIGIN_NOT_ALLOWED` instead of
+running on. Mark a step `risk: destructive` when it deletes or overwrites real data; those steps need
+`--allow-destructive` on the run.
 
 ## Outputs
 

--- a/docs/CLAIMS-AUDIT.md
+++ b/docs/CLAIMS-AUDIT.md
@@ -37,6 +37,11 @@ Status terms:
 | Runner telemetry separates driver duration, runner wall time, attempts, and failing phase | verified | unit event assertions plus live `run-log.jsonl` parsing |
 | `--stdout summary` keeps the complete artifact but emits terminal output only | verified, measured | unit stream/artifact comparison; issue #69 o200k_base measurement below |
 | Step `perf_budget_ms` measures action through observable wait/assert and excludes capture/startup | verified | pass/exceedance unit tests with a delayed capture |
+| `allowed_origins` is enforced against the live URL after every step, not only against declared targets | verified | redirect and lookalike-host cases in `tests/test_flow_runner.py` |
+| Origin comparison parses the URL, so a host that merely starts with an allowed origin is rejected | verified | `OriginHelperTests` suffix case plus the lookalike run |
+| A step marked `risk: destructive` cannot run without `--allow-destructive`, and the session never starts | verified | blocked/allowed unit pair asserting the session counter |
+| The origin check is excluded from `perf_budget_ms` | verified | budget run asserting `outcome_ms` below step `total_ms` with an `origin` phase present |
+| A flow that declares no `allowed_origins` keeps its previous behaviour and pays no extra round trip | verified | no-policy run asserting `origin_gate: not-declared` |
 | Missing/old driver fails as `DRIVER_INCOMPATIBLE` rather than using a silent fallback | verified | `tests/test_flow_runner.py` |
 | Success/failure screenshots follow scenario/step capture policy | verified | runner unit tests and live fixture |
 

--- a/references/flow-spec.md
+++ b/references/flow-spec.md
@@ -27,6 +27,10 @@ $env:TEIBTO_CDP_SCRIPT = 'D:\path\to\teibto-dev-standards\scripts\cdp.py'
 - artifact อยู่ที่ `<out>/run-log.jsonl`, `<out>/qa-report.md`, `<out>/shots/`
 - `--stdout summary` ลด output เข้า agent context แต่ `run-log.jsonl` ยังเก็บ event เต็มเหมือนเดิม
 - `perf_budget_ms` ระดับ step วัด action → explicit wait → assertion; ไม่รวม startup/capture
+- `allowed_origins` ระดับ story เปิด origin gate: ตรวจทั้งเป้าหมายที่ประกาศไว้ (ก่อนเปิดเบราว์เซอร์)
+  และ URL จริงหลังทุก step (จับ redirect); หลุด = `ORIGIN_NOT_ALLOWED` และหยุด scenario
+- `risk: read|write|destructive` ระดับ step; `destructive` ต้องสั่ง `--allow-destructive` ไม่งั้น
+  runner ปฏิเสธ flow ตั้งแต่ก่อนเริ่ม (`DESTRUCTIVE_NOT_ALLOWED`)
 
 Local UI (ไม่จำเป็นต่อ CI):
 
@@ -50,6 +54,8 @@ regression ได้, เติม vars ต่างค่าเพื่อย�
 story: <slug>                    # id สั้นๆ ของ flow (ใช้ตั้งชื่อโฟลเดอร์ artifact)
 title: <ชื่ออ่านเข้าใจ>          # ขึ้นหัว guide/report
 ticket: <PROJ-123>               # (team) link กลับ requirement/ticket — ไหลเข้า qa-report + guide
+allowed_origins:                 # optional; ประกาศแล้ว = เปิด origin gate (ไม่ประกาศ = พฤติกรรมเดิม)
+  - "https://1234567-sb1.app.netsuite.com"     # origin เต็มเท่านั้น ไม่รับ wildcard
 
 vars:                            # ค่าที่ inject ผ่าน {{name}} — UI render เป็นช่องกรอก
   - { name: base_url, label: URL, default: "https://..." }
@@ -68,6 +74,7 @@ scenarios:
         value: "<ค่า/ข้อความ (สำหรับ fill/select) — รองรับ {{var}}>"
         wait: networkidle | <ms> | "<selector>" | "fn:<js>"  # รอหลัง action
         perf_budget_ms: 3000       # optional; เกินแล้ว PERF_BUDGET_EXCEEDED + FAIL
+        risk: read|write|destructive   # optional (default read); destructive ต้อง --allow-destructive
         capture: true|false        # override screenshot policy ของ scenario นี้
         assert:                  # พิสูจน์ผล (ตาม gotchas: อย่าเชื่อ ✓Done)
           url_contains: "/inventory.html"
@@ -105,6 +112,27 @@ timing ของตัวเอง และ `run_done` แยก startup/total.
 explicit wait/assert โดยไม่รวม screenshot; `run_done.performance_budgets` สรุป pass/evaluated/total.
 เกิน budget = typed failure `PERF_BUDGET_EXCEEDED` และเก็บ failure evidence ตาม capture policy.
 
+## Origin gate และ risk class
+
+**ทำไมต้องตรวจซ้ำหลัง navigation:** เป้าหมายที่เขียนไว้ใน flow ผ่านการตรวจก่อนเปิดเบราว์เซอร์ แต่ SSO
+หรือ redirect ฝั่ง server พาไปที่อื่นได้หลังจากนั้น — การตรวจครั้งเดียวตอนต้นจึงเป็นด่านที่ fail open.
+Runner อ่าน `url` จริงหลัง action + wait ของทุก step **เมื่อ flow ประกาศ `allowed_origins` เท่านั้น**
+(flow ที่ไม่ประกาศไม่จ่าย round trip เพิ่มเลย)
+
+**ทำไมต้อง parse ไม่ใช่เทียบ prefix:** `https://sb1.example.com.attacker.test` ขึ้นต้นด้วย origin ที่
+อนุญาตเมื่อมองเป็นสตริง แต่เป็นคนละ origin เมื่อมองเป็น URL · `origin_violation()` จึง parse แล้วเทียบ
+`scheme://host[:port]` ทั้งก้อน และปฏิเสธทุก scheme ที่ไม่ใช่ `http`/`https`
+
+**ลำดับใน step:** action → wait → **origin gate** → assert · ด่านอยู่ก่อน assert เพราะถ้า assert ก่อน
+ผลที่ได้จะเป็น `ASSERTION_FAILED` ซึ่งกลบข้อเท็จจริงว่า run หลุดออกนอกขอบเขตไปแล้ว
+
+**ไม่นับรวมใน perf budget:** เวลาที่ใช้อ่าน `url` ของด่านถูกหักออกจาก `outcome_ms` — flow ที่ประกาศ
+origin ของตัวเองไม่ควรถูกลงโทษด้วย budget ที่เข้มขึ้น
+
+**รายงาน:** `run_start.run_policy` บอก origin ที่อนุญาต, `origin_gate` (`enforced`/`not-declared`),
+จำนวน step แยกตาม risk และว่า destructive ถูกอนุญาตหรือไม่ · `run_done.origin_gate.checks` นับจำนวน
+step ที่ผ่านด่าน · `qa-report.md` ขึ้นสองบรรทัดบนหัวรายงาน
+
 **Traceability (สำหรับทีม):** `ticket`/`requirement` + `acceptance` ทำให้ตอบได้ว่า *test นี้ยืนยัน
 req ไหน* และ *req นี้ครอบด้วย scenario ไหน*. 1 acceptance criterion → 1 scenario (map 1:1) →
 qa-report + user-guide อ้าง req เดียวกัน = ปิด loop req→test→doc. ดู playbook ทีมใน repo:
@@ -120,6 +148,10 @@ ignore เงียบ ๆ.
 
 `perf_budget` แบบ object/scenario เดิมยังถูกปฏิเสธ; executable contract คือ integer
 `perf_budget_ms` ที่ step เท่านั้น.
+
+`allowed_origins` และ `risk` **เป็น executable field แล้ว** (schema + พฤติกรรมตอนรัน + การรายงาน +
+เทสตอนล้ม ship พร้อมกัน) · `allowed_origins` รับเฉพาะ origin เต็ม ไม่รับ wildcard ระดับ subdomain
+เพราะ wildcard คือช่องที่ทำให้ด่านนี้ fail open ได้เงียบที่สุด.
 
 - เก็บ release/quarantine/coverage state ใน `qa/<feature>/coverage.yaml`.
 - ทำ setup/teardown เป็น orchestration แยก โดยใช้ scoped marker, identify-before-mutate และ dirty-state

--- a/schemas/flow.schema.json
+++ b/schemas/flow.schema.json
@@ -10,6 +10,11 @@
     "title": {"type": "string", "minLength": 1},
     "ticket": {"type": "string"},
     "target": {"type": "string"},
+    "allowed_origins": {
+      "type": "array",
+      "minItems": 1,
+      "items": {"type": "string", "pattern": "^https?://[A-Za-z0-9._-]+(?::[0-9]{1,5})?$"}
+    },
     "vars": {
       "type": "array",
       "items": {
@@ -76,6 +81,7 @@
         "value": {"type": ["string", "number", "boolean", "null"]},
         "wait": {"anyOf": [{"const": "networkidle"}, {"type": "integer", "minimum": 0, "maximum": 60000}, {"type": "string", "minLength": 1}]},
         "perf_budget_ms": {"type": "integer", "minimum": 1, "maximum": 600000},
+        "risk": {"enum": ["read", "write", "destructive"]},
         "assert": {"$ref": "#/$defs/assertion"},
         "capture": {"type": "boolean"}
       },

--- a/scripts/flow-runner.py
+++ b/scripts/flow-runner.py
@@ -24,6 +24,7 @@ import threading
 import time
 from pathlib import Path
 from typing import Any, TextIO
+from urllib.parse import urlsplit
 
 import yaml
 from jsonschema import Draft202012Validator
@@ -48,6 +49,9 @@ INPUT_SETTLE_POLICY = "none"
 DIALOG_POLICIES = ("safe", "accept", "dismiss")
 STDOUT_MODES = ("events", "summary")
 SUMMARY_EVENT_TYPES = {"fatal", "run_done"}
+ALLOWED_SCHEMES = ("http", "https")
+RISK_LEVELS = ("read", "write", "destructive")
+DEFAULT_RISK = "read"
 
 
 class RunnerError(RuntimeError):
@@ -128,6 +132,82 @@ def redact(value: Any, secrets: set[str], variables: dict[str, Any], *, truncate
             value = value.replace(secret, "***")
         return value[:MAX_EVENT_TEXT] if truncate else value
     return value
+
+
+def origin_of(url: str) -> str | None:
+    """Return `scheme://host[:port]` lowercased, or None when the URL is not http(s)."""
+    parts = urlsplit(str(url).strip())
+    if parts.scheme.lower() not in ALLOWED_SCHEMES or not parts.netloc:
+        return None
+    return f"{parts.scheme.lower()}://{parts.netloc.lower()}"
+
+
+def origin_violation(url: str, allowed: list[str]) -> str | None:
+    """Describe why `url` is outside `allowed`, or None when it is inside.
+
+    Parsed, never prefix-matched: `https://sb1.example.com.attacker.test` starts with an
+    allowed origin as a string and is a different origin as a URL. That difference is the
+    whole point of the gate, so a redirect is checked the same way a declared target is.
+    """
+    origin = origin_of(url)
+    if origin is None:
+        return f"scheme is not http/https: {str(url)[:200]}"
+    if origin not in allowed:
+        return f"origin {origin} is not in allowed_origins ({', '.join(allowed)})"
+    return None
+
+
+def flow_policy(flow: dict[str, Any]) -> dict[str, Any]:
+    """Summarise the declared run policy without deciding anything."""
+    counts = {level: 0 for level in RISK_LEVELS}
+    destructive: list[str] = []
+    for scenario in flow["scenarios"]:
+        for index, step in enumerate(scenario["steps"], 1):
+            level = step.get("risk", DEFAULT_RISK)
+            counts[level] = counts.get(level, 0) + 1
+            if level == "destructive":
+                destructive.append(f"{scenario['id']}#{index}")
+    return {
+        "allowed_origins": list(flow.get("allowed_origins") or []),
+        "risk_counts": counts,
+        "destructive_steps": destructive,
+    }
+
+
+def enforce_policy(policy: dict[str, Any], flow: dict[str, Any], variables: dict[str, Any],
+                   *, allow_destructive: bool) -> list[str]:
+    """Fail closed before the browser is touched; return the normalised allowed origins.
+
+    A flow that declares nothing keeps its old behaviour, so the gate is opt-in per flow
+    rather than a breaking change to every existing flow.
+    """
+    if policy["destructive_steps"] and not allow_destructive:
+        raise RunnerError(
+            "DESTRUCTIVE_NOT_ALLOWED",
+            "step ที่ risk: destructive ต้องสั่ง --allow-destructive: "
+            + ", ".join(policy["destructive_steps"]),
+            detail={"steps": policy["destructive_steps"]},
+        )
+    allowed: list[str] = []
+    for raw in policy["allowed_origins"]:
+        origin = origin_of(raw)
+        if origin is None:
+            raise RunnerError("INVALID_ALLOWED_ORIGIN",
+                              f"allowed_origins ต้องเป็น http(s) origin: {raw}")
+        allowed.append(origin)
+    if not allowed:
+        return allowed
+    for scenario in flow["scenarios"]:
+        for index, step in enumerate(scenario["steps"], 1):
+            if step["action"] != "open":
+                continue
+            target = str(substitute(step.get("target", ""), variables))
+            problem = origin_violation(target, allowed)
+            if problem:
+                raise RunnerError("ORIGIN_NOT_ALLOWED", f"{scenario['id']}#{index}: {problem}",
+                                  detail={"scenario": scenario["id"], "index": index,
+                                          "url": target})
+    return allowed
 
 
 def resolve_cdp_script(explicit: str | None) -> Path:
@@ -552,7 +632,7 @@ def flow_meta(flow: dict[str, Any], path: Path, *, full: bool = False) -> dict[s
 
 def run_flow(flow: dict[str, Any], path: Path, output_dir: Path, variables: dict[str, Any],
              cdp_script: Path, target_id: str, port: str | None, sink: EventSink,
-             dialog: str = "safe") -> int:
+             dialog: str = "safe", allow_destructive: bool = False) -> int:
     run_started = time.perf_counter()
     output_dir.mkdir(parents=True, exist_ok=True)
     shots = output_dir / "shots"
@@ -566,6 +646,9 @@ def run_flow(flow: dict[str, Any], path: Path, output_dir: Path, variables: dict
     perf_total = sum(1 for scenario in flow["scenarios"] for step in scenario["steps"]
                      if step.get("perf_budget_ms") is not None)
     perf_evaluated = perf_passed = 0
+    policy = flow_policy(flow)
+    allowed_origins: list[str] = []
+    origin_checks = 0
     session: CDPSession | None = None
 
     def flush_dialogs(scenario_id: str, index: int | None, global_index: int | None) -> None:
@@ -584,11 +667,17 @@ def run_flow(flow: dict[str, Any], path: Path, output_dir: Path, variables: dict
                                  "dialog": dialog,
                                  "dialog_evidence": "structured-per-command",
                                  "navigation": "event-bound-load"},
+               "run_policy": {"allowed_origins": policy["allowed_origins"],
+                              "origin_gate": "enforced" if policy["allowed_origins"] else "not-declared",
+                              "risk_counts": policy["risk_counts"],
+                              "destructive_allowed": allow_destructive},
                "scenarios": [{"id": item["id"], "steps": len(item["steps"])}
                              for item in flow["scenarios"]]})
     startup_started = time.perf_counter()
     startup_ms: float | None = None
     try:
+        allowed_origins = enforce_policy(policy, flow, variables,
+                                         allow_destructive=allow_destructive)
         session = CDPSession(cdp_script, target_id, port=port, dialog=dialog)
         startup_ms = round((time.perf_counter() - startup_started) * 1000, 3)
         sink.emit({"type": "session_ready", "target_id": target_id,
@@ -612,6 +701,21 @@ def run_flow(flow: dict[str, Any], path: Path, output_dir: Path, variables: dict
                 try:
                     context = perform_action(session, raw_step, variables, timings)
                     perform_wait(session, raw_step.get("wait"), variables, context, timings)
+                    # The gate runs before the assertion so an escape is reported as an escape.
+                    # Asserting first on a foreign page would surface ASSERTION_FAILED and hide
+                    # the fact that the run had already left its declared origins.
+                    guard_ms = 0.0
+                    if allowed_origins:
+                        guard_started = time.perf_counter()
+                        current_url = str(
+                            timings.command(session, "origin", "url").get("data") or "")
+                        guard_ms = (time.perf_counter() - guard_started) * 1000
+                        problem = origin_violation(current_url, allowed_origins)
+                        if problem:
+                            timings.fail("origin")
+                            raise RunnerError("ORIGIN_NOT_ALLOWED", problem,
+                                              detail={"url": current_url})
+                        origin_checks += 1
                     assertion = raw_step.get("assert")
                     status, detail = "done", ""
                     if assertion:
@@ -626,7 +730,9 @@ def run_flow(flow: dict[str, Any], path: Path, output_dir: Path, variables: dict
                         status, detail = "unverified", "state-changing step has no explicit assertion"
                     budget_ms = raw_step.get("perf_budget_ms")
                     if budget_ms is not None:
-                        outcome_ms = timings.elapsed_ms()
+                        # The origin gate is policy, not the application's observable outcome,
+                        # so a flow does not get a stricter budget for declaring its origins.
+                        outcome_ms = round(timings.elapsed_ms() - guard_ms, 3)
                         perf_evaluated += 1
                         within_budget = outcome_ms <= budget_ms
                         performance = {
@@ -748,6 +854,14 @@ def run_flow(flow: dict[str, Any], path: Path, output_dir: Path, variables: dict
     if perf_total:
         summary.insert(3, f"**Performance budgets:** {perf_passed}/{perf_total} passed "
                           f"({perf_evaluated} evaluated)")
+    if policy["allowed_origins"]:
+        summary.insert(0, f"**Allowed origins:** {', '.join(policy['allowed_origins'])} "
+                          f"({origin_checks} step checks passed)")
+    else:
+        summary.insert(0, "**Allowed origins:** none declared — origin gate not enforced")
+    risky = ", ".join(f"{level}={policy['risk_counts'][level]}" for level in RISK_LEVELS)
+    summary.insert(1, f"**Step risk:** {risky} "
+                      f"(destructive {'allowed' if allow_destructive else 'blocked'})")
     report[4:4] = summary
     safe_report = redact("\n".join(report), sink.secrets, variables, truncate=False)
     report_path.write_text(str(safe_report), encoding="utf-8")
@@ -755,6 +869,9 @@ def run_flow(flow: dict[str, Any], path: Path, output_dir: Path, variables: dict
                "failures": failures, "unverified": unverified, "dialogs": dialogs,
                "performance_budgets": {"passed": perf_passed, "evaluated": perf_evaluated,
                                        "total": perf_total},
+               "origin_gate": {"allowed": policy["allowed_origins"], "checks": origin_checks,
+                               "enforced": bool(policy["allowed_origins"])},
+               "risk_counts": policy["risk_counts"],
                "verdict": verdict,
                "duration_ms": round((time.perf_counter() - run_started) * 1000, 3),
                "startup_ms": startup_ms,
@@ -787,6 +904,8 @@ def main(argv: list[str] | None = None) -> int:
                         help="dialog policy handed to cdp.py (default: safe; never inherited from env)")
     parser.add_argument("--stdout", choices=STDOUT_MODES, default="events",
                         help="events (default) or terminal summary only; run-log.jsonl is always complete")
+    parser.add_argument("--allow-destructive", action="store_true",
+                        help="allow steps declared risk: destructive; blocked by default")
     parser.add_argument("--meta", action="store_true")
     parser.add_argument("--full", action="store_true")
     args = parser.parse_args(argv)
@@ -816,7 +935,8 @@ def main(argv: list[str] | None = None) -> int:
         sink = EventSink(sys.stdout, log_path, secret_names(flow), variables,
                          stdout_mode=args.stdout)
         return run_flow(flow, path, output_dir, variables, cdp_script,
-                        args.target_id or "", args.cdp_port, sink, dialog=args.dialog)
+                        args.target_id or "", args.cdp_port, sink, dialog=args.dialog,
+                        allow_destructive=args.allow_destructive)
     except RunnerError as exc:
         payload = {"type": "fatal", "error": {"code": exc.code, "message": str(exc)}}
         if sink:

--- a/tests/fixtures/fake_cdp.py
+++ b/tests/fixtures/fake_cdp.py
@@ -47,7 +47,9 @@ for line in sys.stdin:
         sys.stderr.write(f"[dialog] {kind}: {message} -> {answer}\n")
         sys.stderr.flush()
     if command == "nav":
-        url = args[0]
+        # FAKE_CDP_REDIRECT_TO models a server-side redirect: the navigation is accepted but
+        # the live URL is somewhere else, which is the case a prefix match would let through.
+        url = os.environ.get("FAKE_CDP_REDIRECT_TO") or args[0]
         data = url
     elif command == "fill":
         values[args[0]] = args[1]

--- a/tests/test_flow_runner.py
+++ b/tests/test_flow_runner.py
@@ -28,7 +28,9 @@ def load_runner():
     return module
 
 
-class FlowRunnerTests(unittest.TestCase):
+class RunnerHarness:
+    """Shared fixture plumbing; mixed into a TestCase so suites do not re-run each other."""
+
     def workspace(self) -> Path:
         root = TEST_TMP / uuid.uuid4().hex
         root.mkdir()
@@ -54,6 +56,8 @@ class FlowRunnerTests(unittest.TestCase):
         )
         return process, out, counter
 
+
+class FlowRunnerTests(RunnerHarness, unittest.TestCase):
     def test_pass_uses_one_session_and_redacts_secret(self):
         process, out, counter = self.run_flow("""
             story: login
@@ -390,6 +394,189 @@ class FlowRunnerTests(unittest.TestCase):
         step = next(item for item in payloads if item["type"] == "step_done")
         self.assertEqual("assert", step["timings"]["failing_phase"])
         self.assertIn("capture", step["timings"]["phases"])
+
+
+class OriginAndRiskPolicyTests(RunnerHarness, unittest.TestCase):
+    """BAS-4: a run declares where it is allowed to go, and fails closed when it leaves."""
+
+    ALLOWED = "https://sb1.example.test"
+
+    def payloads(self, out: Path) -> list[dict]:
+        return [json.loads(line) for line in
+                (out / "run-log.jsonl").read_text(encoding="utf-8").splitlines()]
+
+    def test_flow_without_allowed_origins_keeps_previous_behaviour(self):
+        process, out, counter = self.run_flow("""
+            story: no-policy
+            title: No declared origins
+            scenarios:
+              - id: smoke
+                steps:
+                  - {action: open, target: "https://anywhere.test/page", capture: false}
+        """)
+        self.assertEqual(0, process.returncode, process.stdout + process.stderr)
+        self.assertEqual(["start"], counter.read_text(encoding="utf-8").splitlines())
+        start = next(item for item in self.payloads(out) if item["type"] == "run_start")
+        self.assertEqual("not-declared", start["run_policy"]["origin_gate"])
+        done = next(item for item in self.payloads(out) if item["type"] == "run_done")
+        self.assertFalse(done["origin_gate"]["enforced"])
+        self.assertIn("none declared", (out / "qa-report.md").read_text(encoding="utf-8"))
+
+    def test_declared_target_outside_allowed_origins_fails_before_the_browser(self):
+        process, out, counter = self.run_flow(f"""
+            story: wrong-origin
+            title: Declared target escapes
+            allowed_origins: ["{self.ALLOWED}"]
+            scenarios:
+              - id: smoke
+                steps:
+                  - {{action: open, target: "https://prod.example.test/app", capture: false}}
+        """)
+        self.assertEqual(1, process.returncode)
+        self.assertFalse(counter.exists(), "the session must not start once the flow is rejected")
+        fatal = next(item for item in self.payloads(out) if item["type"] == "fatal")
+        self.assertEqual("ORIGIN_NOT_ALLOWED", fatal["error"]["code"])
+        self.assertIn("prod.example.test", fatal["error"]["message"])
+
+    def test_redirect_outside_allowed_origins_fails(self):
+        """The declared target is fine; the live URL is not. Only a post-navigation check sees it."""
+        process, out, _ = self.run_flow(f"""
+            story: redirected
+            title: Redirect escapes
+            allowed_origins: ["{self.ALLOWED}"]
+            scenarios:
+              - id: smoke
+                steps:
+                  - {{action: open, target: "{self.ALLOWED}/login", capture: false}}
+        """, env_overrides={"FAKE_CDP_REDIRECT_TO": "https://prod.example.test/app"})
+        self.assertEqual(1, process.returncode)
+        step = next(item for item in self.payloads(out) if item["type"] == "step_done")
+        self.assertEqual("ORIGIN_NOT_ALLOWED", step["error"]["code"])
+        self.assertEqual("origin", step["timings"]["failing_phase"])
+
+    def test_lookalike_host_is_rejected_where_a_prefix_match_would_pass(self):
+        lookalike = f"{self.ALLOWED}.attacker.test/app"
+        self.assertTrue(lookalike.startswith(self.ALLOWED), "fixture must fool a prefix match")
+        process, out, _ = self.run_flow(f"""
+            story: lookalike
+            title: Lookalike host
+            allowed_origins: ["{self.ALLOWED}"]
+            scenarios:
+              - id: smoke
+                steps:
+                  - {{action: open, target: "{self.ALLOWED}/login", capture: false}}
+        """, env_overrides={"FAKE_CDP_REDIRECT_TO": lookalike})
+        self.assertEqual(1, process.returncode)
+        step = next(item for item in self.payloads(out) if item["type"] == "step_done")
+        self.assertEqual("ORIGIN_NOT_ALLOWED", step["error"]["code"])
+
+    def test_non_http_scheme_is_rejected(self):
+        process, out, counter = self.run_flow(f"""
+            story: bad-scheme
+            title: Non-http scheme
+            allowed_origins: ["{self.ALLOWED}"]
+            scenarios:
+              - id: smoke
+                steps:
+                  - {{action: open, target: "javascript:alert(1)", capture: false}}
+        """)
+        self.assertEqual(1, process.returncode)
+        self.assertFalse(counter.exists())
+        fatal = next(item for item in self.payloads(out) if item["type"] == "fatal")
+        self.assertEqual("ORIGIN_NOT_ALLOWED", fatal["error"]["code"])
+        self.assertIn("scheme is not http/https", fatal["error"]["message"])
+
+    def test_destructive_step_is_blocked_without_the_run_level_opt_in(self):
+        process, out, counter = self.run_flow("""
+            story: destructive
+            title: Destructive step
+            scenarios:
+              - id: cleanup
+                steps:
+                  - action: click
+                    target: "#delete-everything"
+                    risk: destructive
+                    assert: {target: "#notice", contains: "saved"}
+                    capture: false
+        """)
+        self.assertEqual(1, process.returncode)
+        self.assertFalse(counter.exists())
+        fatal = next(item for item in self.payloads(out) if item["type"] == "fatal")
+        self.assertEqual("DESTRUCTIVE_NOT_ALLOWED", fatal["error"]["code"])
+        self.assertIn("cleanup#1", fatal["error"]["message"])
+
+    def test_destructive_step_runs_with_the_opt_in(self):
+        process, out, counter = self.run_flow("""
+            story: destructive-ok
+            title: Destructive step allowed
+            scenarios:
+              - id: cleanup
+                steps:
+                  - action: click
+                    target: "#delete-everything"
+                    risk: destructive
+                    assert: {target: "#notice", contains: "saved"}
+                    capture: false
+        """, extra_args=["--allow-destructive"])
+        self.assertEqual(0, process.returncode, process.stdout + process.stderr)
+        self.assertEqual(["start"], counter.read_text(encoding="utf-8").splitlines())
+        start = next(item for item in self.payloads(out) if item["type"] == "run_start")
+        self.assertTrue(start["run_policy"]["destructive_allowed"])
+        self.assertEqual(1, start["run_policy"]["risk_counts"]["destructive"])
+        self.assertIn("destructive allowed", (out / "qa-report.md").read_text(encoding="utf-8"))
+
+    def test_origin_check_is_not_charged_to_the_performance_budget(self):
+        """perf_budget_ms measures the application's observable outcome, not our policy check."""
+        process, out, _ = self.run_flow(f"""
+            story: budget
+            title: Budget with the gate on
+            allowed_origins: ["{self.ALLOWED}"]
+            scenarios:
+              - id: smoke
+                steps:
+                  - action: open
+                    target: "{self.ALLOWED}/page"
+                    perf_budget_ms: 600000
+                    capture: false
+        """)
+        self.assertEqual(0, process.returncode, process.stdout + process.stderr)
+        step = next(item for item in self.payloads(out) if item["type"] == "step_done")
+        self.assertIn("origin", step["timings"]["phases"])
+        self.assertLess(step["performance"]["outcome_ms"], step["timings"]["total_ms"])
+        done = next(item for item in self.payloads(out) if item["type"] == "run_done")
+        self.assertEqual(1, done["origin_gate"]["checks"])
+
+
+class OriginHelperTests(unittest.TestCase):
+    """Pure helpers, so the parsing rules are pinned without starting a run."""
+
+    def setUp(self) -> None:
+        self.runner = load_runner()
+
+    def test_origin_of_normalises_case_and_keeps_the_port(self):
+        self.assertEqual("https://sb1.example.test:8443",
+                         self.runner.origin_of("HTTPS://SB1.Example.Test:8443/path?q=1#x"))
+
+    def test_origin_of_rejects_other_schemes(self):
+        for url in ("javascript:alert(1)", "file:///c:/tmp/x.html", "data:text/html,hi", "", "/rel"):
+            with self.subTest(url=url):
+                self.assertIsNone(self.runner.origin_of(url))
+
+    def test_origin_violation_distinguishes_host_suffixes(self):
+        allowed = ["https://sb1.example.test"]
+        self.assertIsNone(self.runner.origin_violation("https://sb1.example.test/a/b", allowed))
+        self.assertIsNotNone(
+            self.runner.origin_violation("https://sb1.example.test.attacker.test/", allowed))
+        self.assertIsNotNone(self.runner.origin_violation("http://sb1.example.test/", allowed))
+
+    def test_flow_policy_defaults_missing_risk_to_read(self):
+        policy = self.runner.flow_policy({
+            "scenarios": [{"id": "s", "steps": [{"action": "click"},
+                                                {"action": "click", "risk": "write"},
+                                                {"action": "click", "risk": "destructive"}]}]
+        })
+        self.assertEqual({"read": 1, "write": 1, "destructive": 1}, policy["risk_counts"])
+        self.assertEqual(["s#3"], policy["destructive_steps"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## ปัญหา

flow ไม่มีทางบอกว่ามันได้รับอนุญาตให้ไปที่ไหน SSO hop หรือ redirect ฝั่ง server ย้าย run จาก sandbox ไป production ได้ แล้ว runner เดินต่อจนจบเพราะไม่มีใครเฝ้า — pain **C4** ใน `docs/BROWSER-AGENT-STANDARD.md` ที่ก่อนหน้านี้ไม่มีอะไรครอบเลย

## `allowed_origins` — ตรวจสองชั้น

| ชั้น | ตรวจเมื่อไร | จับอะไร |
|---|---|---|
| เป้าหมายที่ประกาศไว้ | **ก่อนเปิดเบราว์เซอร์** | URL ผิดใน flow — ไม่เสีย session เลย |
| URL จริง | **หลังทุก step** (action → wait → gate → assert) | redirect / SSO |

ชั้นที่สองคือชั้นที่สำคัญ: ในเคส redirect **ชั้นแรกผ่าน** การตรวจครั้งเดียวตอนต้นจึงเป็นด่านที่ fail open พอดี

### เทียบด้วยการ parse ไม่ใช่ prefix

`https://sb1.example.com.attacker.test` ขึ้นต้นด้วย origin ที่อนุญาตเมื่อมองเป็นสตริง แต่เป็นคนละ origin เมื่อมองเป็น URL `test_lookalike_host_is_rejected_where_a_prefix_match_would_pass` **assert ก่อนว่า fixture หลอก prefix match ได้จริง** แล้วค่อย assert ว่าเราปฏิเสธ — ถ้าวันหนึ่งมีคนเปลี่ยนไปใช้ `startswith` เทสนี้จะแดง

`allowed_origins` รับ **origin เต็มเท่านั้น ไม่รับ wildcard** ตอบ open question ในตัว issue: wildcard ระดับ subdomain คือช่องที่ทำให้ด่านนี้ fail open ได้เงียบที่สุด

### ลำดับใน step: ด่านอยู่ก่อน assert

ถ้า assert ก่อน ผลที่ได้จะเป็น `ASSERTION_FAILED` ซึ่งกลบข้อเท็จจริงว่า run หลุดออกนอกขอบเขตไปแล้ว — คนอ่านรายงานจะไปไล่ selector แทนที่จะเห็นว่าเดินผิดที่

### ไม่คิดเวลาด่านเข้า perf budget

เวลาที่ใช้อ่าน `url` ถูกหักออกจาก `outcome_ms` — `perf_budget_ms` วัด **ผลลัพธ์ที่สังเกตได้ของแอป** ไม่ใช่ policy check ของเรา flow ที่ประกาศ origin ของตัวเองไม่ควรถูกลงโทษด้วย budget ที่เข้มขึ้น มีเทสยืนยัน (`outcome_ms < total_ms` และมี phase `origin` อยู่จริง)

## `risk` ระดับ step

`risk: read | write | destructive` (default `read`) · `destructive` ต้องสั่ง `--allow-destructive` ที่ระดับ run มิฉะนั้น runner ปฏิเสธ flow **ตั้งแต่ก่อนเปิด session** (`DESTRUCTIVE_NOT_ALLOWED`) เจตนาที่จะลบหรือทับข้อมูลจริงจึงอยู่ในไฟล์ ไม่ใช่สิ่งที่ค้นพบตอนรัน

## เข้ากันได้กับของเดิม

flow ที่ไม่ประกาศ `allowed_origins` **ทำงานเหมือนเดิมทุกอย่างและไม่จ่าย round trip เพิ่มเลย** — ด่านนี้ opt-in ต่อ flow ไม่ใช่การเปลี่ยนพฤติกรรมของทุก flow ที่มีอยู่ มีเทสยืนยัน (`origin_gate: not-declared`)

ship เป็นชุดเดียวตามกฎ executable-flow authority โดยเดินตามรูปที่ `perf_budget_ms` (#69) ทำไว้: schema + พฤติกรรมตอนรัน + การรายงาน + typed failure + เทสตอนล้ม

## เทสที่เพิ่ม

| เทส | ยืนยันอะไร |
|---|---|
| `test_flow_without_allowed_origins_keeps_previous_behaviour` | ไม่ประกาศ = พฤติกรรมเดิม |
| `test_declared_target_outside_allowed_origins_fails_before_the_browser` | หยุดก่อนเปิด session (assert ว่าไฟล์ counter ไม่ถูกสร้าง) |
| `test_redirect_outside_allowed_origins_fails` | เคสที่ด่านชั้นเดียวจะปล่อยผ่าน |
| `test_lookalike_host_is_rejected_where_a_prefix_match_would_pass` | prefix match จะพัง เราไม่พัง |
| `test_non_http_scheme_is_rejected` | `javascript:` ถูกปฏิเสธก่อนถึง driver |
| `test_destructive_step_is_blocked_without_the_run_level_opt_in` | บล็อกก่อนเปิด session |
| `test_destructive_step_runs_with_the_opt_in` | เปิดแล้วรันได้ และรายงานบอกว่าอนุญาต |
| `test_origin_check_is_not_charged_to_the_performance_budget` | budget ไม่ถูกทำให้เข้มขึ้น |
| `OriginHelperTests` × 4 | normalise case/port, ปฏิเสธ scheme อื่น, แยก host suffix, `risk` default เป็น `read` |

`tests/fixtures/fake_cdp.py` ได้ `FAKE_CDP_REDIRECT_TO` เพื่อจำลอง redirect: navigation สำเร็จแต่ URL จริงอยู่ที่อื่น

## หลักฐาน

```
python -m unittest discover -s tests      52 passed
bash tests/test-flow-runner-live.sh       1 real-Chrome run, 0 failures (protocol v3)
bash self-test/smoke-test.sh              41 passed, 0 failed
python scripts/validate-skill.py          PASS
node --check app/server.js                ok
```

## หมายเหตุสำหรับรีวิว

- **สองสวีทใน `tests/test_flow_runner.py` แชร์ `RunnerHarness` แล้ว** — คลาสใหม่เดิม inherit `FlowRunnerTests` ซึ่งทำให้เทสเดิมถูกรันซ้ำทั้งชุด (44 → 28 tests หลังแก้)
- **ไม่ใส่ `allowed_origins` ลง `examples/saucedemo.yaml`** ตั้งใจ — ตัวอย่างมีไว้ให้ copy แล้วเปลี่ยน `base_url` การ pre-wire ด่านไว้กับ host เดียวจะทำให้ทุกคนที่ copy ไปเจอ `ORIGIN_NOT_ALLOWED` quick reference ใน `flow-spec.md` แสดงวิธีใช้แทน
- `DESTRUCTIVE_NOT_ALLOWED` ตั้งชื่อต่างจาก `ORIGIN_NOT_ALLOWED` ที่ระบุใน issue เพราะเป็นคนละเงื่อนไข — ทั้งคู่เป็น typed failure ที่ปรากฏใน `run-log.jsonl` และ report

Closes #79
Part of #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WF2vGyjyjvaRw4n6NuzmV7
